### PR TITLE
Split up `@hensm/ddcci` into a separate script - Win32 bug can't adjust brightness after unhook and hook the monitor back in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "display-dj",
   "private": true,
-  "version": "1.5.7",
+  "version": "1.6.0",
   "description": "A cross platform desktop application that supports brightness adjustment for integrated laptop monitor as well as external monitors and dark mode toggle supporting Windows and MacOSX at the moment.",
   "scripts": {
     "clean-dist": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "display-dj",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A cross platform desktop application that supports brightness adjustment for integrated laptop monitor as well as external monitors and dark mode toggle supporting Windows and MacOSX at the moment.",
   "scripts": {
     "clean-dist": "rimraf dist",

--- a/prebuild.js
+++ b/prebuild.js
@@ -19,6 +19,7 @@ switch (process.platform) {
     files.push([`src/main/utils/DisplayAdapter.Win32.ts`, DEST_IMPL_DISPLAY_UTILS]);
     files.push([`src/main/utils/SoundUtils.Win32.ts`, DEST_IMPL_SOUND_UTILS]);
     files.push([`src/binaries/win32_volume_helper.exe`, path.join(DEV_ELECTRON_WIN32_RESOURCE_PATH ,`win32_volume_helper.exe`)]);
+    files.push([`src/binaries/win32_ddcci.js`, path.join(DEV_ELECTRON_WIN32_RESOURCE_PATH ,`win32_ddcci.js`)]);
     break;
   case 'darwin':
     const DEV_ELECTRON_DARWIN_RESOURCE_PATH = `node_modules/electron/dist/Electron.app/Contents/Resources`;

--- a/src/binaries/win32_ddcci.js
+++ b/src/binaries/win32_ddcci.js
@@ -1,0 +1,42 @@
+const ddcci = require("@hensm/ddcci");
+
+console.log('Child Process Spawned')
+
+process.on('message', function(msg) {
+  console.log('Child received message', msg);
+
+  const monitorIdToChange = msg[0];
+  const newBrightness = parseInt(msg[1]);
+
+  _changeBrightness(monitorIdToChange, newBrightness);
+  process.send('ChildMessage');
+});
+
+function _changeBrightness(){
+  console.log('monitorIdToChange', monitorIdToChange)
+  console.log('newBrightness', newBrightness)
+
+  if(isNaN(newBrightness) || newBrightness < 0 || newBrightness > 100){
+    console.log('No data', process.argv)
+    process.exit(1);
+  }
+
+  for (const monitorId of ddcci.getMonitorList()) {
+    console.log('monitorId', monitorId)
+    if(monitorId === monitorIdToChange){
+      try{
+        ddcci.setBrightness(monitorId, newBrightness);
+        console.log('Successfully set brightness for monitor', monitorIdToChange, newBrightness);
+        process.exit(0);
+      } catch(err){
+        console.log('Failed to set brightness for monitor', monitorIdToChange, newBrightness, err);
+        process.exit(1);
+      }
+
+    }
+  }
+
+  console.log('Monitor ID not found');
+  process.exit(1);
+}
+

--- a/src/main/utils/DisplayAdapter.Win32.ts
+++ b/src/main/utils/DisplayAdapter.Win32.ts
@@ -1,9 +1,10 @@
 import path from 'path';
 import cp from 'child_process';
-import * as ddcci from '@hensm/ddcci';
 import { executePowershell } from 'src/main/utils/ShellUtils';
 import { IDisplayAdapter, Monitor } from 'src/types.d';
+
 // source: https://github.com/hensm/node-ddcci
+const _getDdcciScript = async () => path.join(process['resourcesPath'], `win32_ddcci.js`);
 
 /**
  * get current laptop brightness. more info here
@@ -33,7 +34,7 @@ function _getBrightnessDccCi(targetMonitorId: string): Promise<number> {
 
     while (--retry > 0) {
       try {
-        const res = await ddcci.getBrightness(targetMonitorId);
+        const res = await _sendMessageToBackgroundScript('getBrightness', targetMonitorId);
         resolve(res);
       } catch (err) {
         error = err;
@@ -44,22 +45,30 @@ function _getBrightnessDccCi(targetMonitorId: string): Promise<number> {
   });
 }
 
+async function _getMonitorList(){
+  return _sendMessageToBackgroundScript('getMonitorList');
+}
+
 async function _setBrightnessDccCi(targetMonitorId: string, newBrightness: number): Promise<void> {
-  // await ddcci.setBrightness(targetMonitorId, newBrightness);
-  const scriptPath = path.join(process['resourcesPath'], `win32_ddcci.js`)
+  return _sendMessageToBackgroundScript('setBrightness', targetMonitorId, newBrightness);
+}
 
-  const childProcess = cp.fork(scriptPath);
+async function _sendMessageToBackgroundScript(command : 'getBrightness'| 'setBrightness' | 'getMonitorList', ...extra: any) : Promise<any>{
+  return new Promise(async (resolve, reject) => {
+    const childProcess = cp.fork(await _getDdcciScript());
 
-  childProcess.on('message', function(m) {
-    console.log('PARENT got message:', m);
-  });
+    childProcess.on('message', function(response: any) {
+      const {success, data} = response;
+      success === true ? resolve(data) : reject();
+    });
 
-  childProcess.send([targetMonitorId, newBrightness]);
+    childProcess.send([command, ...extra]);
+  })
 }
 
 const DisplayAdapter: IDisplayAdapter = {
   getMonitorList: async () => {
-    return ddcci.getMonitorList();
+    return _getMonitorList();
   },
   getMonitorType: async (targetMonitorId: string) => {
     try {
@@ -96,15 +105,13 @@ const DisplayAdapter: IDisplayAdapter = {
     // monitor is an external (DCC/CI)
     try {
       await _setBrightnessDccCi(targetMonitorId, newBrightness);
-      console.trace(`Update brightness with ddcci successfully`, targetMonitorId, newBrightness);
     } catch (err) {
       // monitor is a laptop
       console.trace(`Update brightness failed with ddcci, trying builtin method`, targetMonitorId, newBrightness);
       try {
         await _setBrightnessBuiltin(newBrightness);
-        console.trace(`Update brightness with ddcci successfully`, targetMonitorId, newBrightness);
       } catch (err) {
-        console.trace(`Update brightness failed`, targetMonitorId, newBrightness);
+        console.error(`Update brightness failed`, targetMonitorId, newBrightness);
       }
     }
   },

--- a/src/main/utils/DisplayAdapter.Win32.ts
+++ b/src/main/utils/DisplayAdapter.Win32.ts
@@ -1,8 +1,7 @@
 import path from 'path';
-import cp from 'child_process';
 import { executePowershell } from 'src/main/utils/ShellUtils';
 import { IDisplayAdapter, Monitor } from 'src/types.d';
-
+import cp from 'child_process';
 // source: https://github.com/hensm/node-ddcci
 const _getDdcciScript = async () => path.join(process['resourcesPath'], `win32_ddcci.js`);
 


### PR DESCRIPTION
Fixes #64 : Win32 bug - can't adjust brightness after unhook and hook the monitor back in

Right now, if you unhook and hook up a monitor. Those display can't be adjusted with `display-dj` due to a bug in `@hensm/ddcci`

## The detailed error
`[0] The operating system asynchronously destroyed the monitor which corresponds to this handle because the operating system's state changed. This error typically occurs because the monitor PDO associated with this handle was removed, the monitor PDO associated with this handle was stopped, or a display mode change occurred. A display mode change occurs when windows sends a WM_DISPLAYCHANGE windows message to applications.`

## The cause
`@hensm/ddcci` is funky when you disconnect and reconnect the external display. This PR breaks up the commands for DDCCI into a separate script and no longer makes it as part of the main bundle.

## The solution
I tried multiple approaches, it seems like the only one that works for me is to break up ddcci related actions into a separate script and has the main display-dj process calls out to this script. It seems the spawning of this new script seems to re-initiate the ddcci module properly.