### PR TITLE
feat(debug): expand diagnostic logging for brightness path (v7.0.10)

### DIFF
--- a/src-tauri/src/core/windows.rs
+++ b/src-tauri/src/core/windows.rs
@@ -44,11 +44,16 @@ impl BuiltinControl {
             "(Get-WmiObject -Namespace root/WMI -Class WmiMonitorBrightnessMethods).WmiSetBrightness(1, {})",
             value
         );
-        hidden_command("powershell")
+        let out = hidden_command("powershell")
             .args(["-NoProfile", "-NonInteractive", "-Command", &cmd])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .output();
+        let ok = out.as_ref().map(|o| o.status.success()).unwrap_or(false);
+        let stderr = out.as_ref().map(|o| String::from_utf8_lossy(&o.stderr).trim().to_string()).unwrap_or_default();
+        log::info!(
+            "set_brightness[builtin/wmi]: value={} return_ok={} stderr={:?}",
+            value, ok, stderr,
+        );
+        ok
     }
 }
 
@@ -103,12 +108,21 @@ impl DisplayControl for ExternalControl {
     fn set_brightness(&mut self, value: u16, mode: &str) -> bool {
         let use_ddc = mode == "ddc" || mode == "force" || (mode == "auto" && self.ddc_supported);
         let use_gamma = mode == "gamma" || mode == "force" || (mode == "auto" && !self.ddc_supported);
+        let mut ddc_attempted = false;
+        let mut ddc_ok = true;
+        let mut ddc_err: Option<String> = None;
         let mut ok = true;
 
         if use_ddc && self.ddc_supported {
+            ddc_attempted = true;
             let ddc_val = if value == 0 { 1 } else { value }; // clamp to 1 to avoid standby
-            if self.ddc_monitor.set_vcp_feature(VCP_BRIGHTNESS, ddc_val).is_err() {
-                ok = false;
+            match self.ddc_monitor.set_vcp_feature(VCP_BRIGHTNESS, ddc_val) {
+                Ok(()) => {}
+                Err(e) => {
+                    ddc_ok = false;
+                    ddc_err = Some(format!("{}", e));
+                    ok = false;
+                }
             }
             thread::sleep(Duration::from_millis(100)); // DDC processing delay
         }
@@ -117,12 +131,29 @@ impl DisplayControl for ExternalControl {
             set_gamma_for_hmonitor(self.hmonitor, value as u32);
         }
 
+        // Per-call diagnostic — surfaces in stderr / env_logger output. Shows which
+        // path(s) ran, whether DDC actually accepted the write, and the raw error
+        // when SetVCPFeature failed. Critical for diagnosing displays that look
+        // "controllable" (ddc_supported=true at enumerate time) but silently reject
+        // brightness writes (common on USB-C panels and some Samsung models).
+        log::info!(
+            "set_brightness[external]: value={} mode={} ddc_supported={} use_ddc={} use_gamma={} ddc_attempted={} ddc_ok={} ddc_err={:?} return_ok={}",
+            value, mode, self.ddc_supported, use_ddc, use_gamma, ddc_attempted, ddc_ok, ddc_err, ok,
+        );
+
         ok
     }
 
     fn set_contrast(&mut self, value: u16) -> bool {
-        if !self.ddc_supported { return false; } // early return
-        self.ddc_monitor.set_vcp_feature(VCP_CONTRAST, value).is_ok()
+        if !self.ddc_supported {
+            log::info!("set_contrast[external]: skipped (ddc_supported=false) value={}", value);
+            return false;
+        }
+        let res = self.ddc_monitor.set_vcp_feature(VCP_CONTRAST, value);
+        let ok = res.is_ok();
+        let err = res.err().map(|e| format!("{}", e));
+        log::info!("set_contrast[external]: value={} return_ok={} err={:?}", value, ok, err);
+        ok
     }
 
     fn reset_gamma(&self) {

--- a/src-tauri/src/dark_mode.rs
+++ b/src-tauri/src/dark_mode.rs
@@ -40,7 +40,14 @@ pub async fn set_dark_mode(
     enabled: bool,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
+    let t0 = std::time::Instant::now();
     log::info!("set_dark_mode: enabled={}", enabled);
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        crate::config::write_debug_log(
+            &state,
+            &format!("set_dark_mode: enabled={} — START", enabled),
+        );
+    }
     let ok = tauri::async_runtime::spawn_blocking(move || {
         crate::core::theme::set_dark_mode(enabled)
     })
@@ -49,10 +56,15 @@ pub async fn set_dark_mode(
     if !ok {
         log::warn!("set_dark_mode: platform layer reported failure");
     }
-    log::info!("set_dark_mode: done");
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    log::info!("set_dark_mode: done platform_ok={} elapsed={:.1}ms", ok, elapsed);
     // Invalidate cache since dark mode changed
     if let Some(state) = app.try_state::<crate::AppState>() {
         state.sidecar_cache.invalidate_dark_mode();
+        crate::config::write_debug_log(
+            &state,
+            &format!("set_dark_mode: enabled={} platform_ok={} — {:.1}ms", enabled, ok, elapsed),
+        );
     }
     crate::tray_icon::set_dark_mode_state(&app, enabled);
     Ok(())

--- a/src-tauri/src/display.rs
+++ b/src-tauri/src/display.rs
@@ -52,33 +52,34 @@ async fn detect_monitors() -> Vec<Monitor> {
 }
 
 /// Set brightness on a single monitor via the in-process platform layer,
-/// clamped to `[min_brightness, 100]`.
-async fn set_monitor_brightness(monitor_id: &str, value: u32, min_brightness: u32) -> Result<(), String> {
+/// clamped to `[min_brightness, 100]`. Returns whether the platform call succeeded.
+async fn set_monitor_brightness(monitor_id: &str, value: u32, min_brightness: u32) -> Result<bool, String> {
     let clamped = value.clamp(min_brightness, 100);
     let id = monitor_id.to_string();
-    log::info!("set_monitor_brightness: id={} value={} clamped={}", id, value, clamped);
+    log::info!("set_monitor_brightness: id={} value={} clamped={} min={}", id, value, clamped, min_brightness);
     let ok = tauri::async_runtime::spawn_blocking(move || {
         crate::core::display::set_one_brightness(&id, clamped as u16, "force")
     })
     .await
     .map_err(|e| format!("brightness task join failed: {}", e))?;
-    if ok { Ok(()) } else { Err(format!("set_brightness failed for monitor {}", monitor_id)) }
+    Ok(ok)
 }
 
 /// Set brightness on all monitors via the in-process platform layer.
-async fn set_all_monitors_brightness(value: u32, min_brightness: u32) -> Result<(), String> {
+/// Returns the per-monitor (id, success) results so the caller can log them.
+async fn set_all_monitors_brightness(value: u32, min_brightness: u32) -> Result<Vec<(String, bool)>, String> {
     let clamped = value.clamp(min_brightness, 100);
-    log::info!("set_all_monitors_brightness: value={} clamped={}", value, clamped);
-    tauri::async_runtime::spawn_blocking(move || {
-        let _ = crate::core::display::set_all_brightness(clamped as u16, "force");
+    log::info!("set_all_monitors_brightness: value={} clamped={} min={}", value, clamped, min_brightness);
+    let results = tauri::async_runtime::spawn_blocking(move || {
+        crate::core::display::set_all_brightness(clamped as u16, "force")
     })
     .await
     .map_err(|e| format!("set_all_brightness task join failed: {}", e))?;
-    Ok(())
+    Ok(results)
 }
 
 /// Set contrast on a single monitor via the in-process platform layer (0-100, DDC-only).
-async fn set_monitor_contrast(monitor_id: &str, value: u32) -> Result<(), String> {
+async fn set_monitor_contrast(monitor_id: &str, value: u32) -> Result<bool, String> {
     let clamped = value.min(100);
     let id = monitor_id.to_string();
     log::info!("set_monitor_contrast: id={} value={}", id, clamped);
@@ -87,19 +88,20 @@ async fn set_monitor_contrast(monitor_id: &str, value: u32) -> Result<(), String
     })
     .await
     .map_err(|e| format!("contrast task join failed: {}", e))?;
-    if ok { Ok(()) } else { Err(format!("set_contrast failed for monitor {}", monitor_id)) }
+    Ok(ok)
 }
 
 /// Set contrast on all monitors via the in-process platform layer.
-async fn set_all_monitors_contrast(value: u32) -> Result<(), String> {
+/// Returns the per-monitor (id, success) results so the caller can log them.
+async fn set_all_monitors_contrast(value: u32) -> Result<Vec<(String, bool)>, String> {
     let clamped = value.min(100);
     log::info!("set_all_monitors_contrast: value={}", clamped);
-    tauri::async_runtime::spawn_blocking(move || {
-        let _ = crate::core::display::set_all_contrast(clamped as u16);
+    let results = tauri::async_runtime::spawn_blocking(move || {
+        crate::core::display::set_all_contrast(clamped as u16)
     })
     .await
     .map_err(|e| format!("set_all_contrast task join failed: {}", e))?;
-    Ok(())
+    Ok(results)
 }
 
 // ===========================================================================
@@ -239,9 +241,29 @@ pub async fn set_brightness(
     monitor_id: String,
     value: u32,
 ) -> Result<(), String> {
+    let t0 = std::time::Instant::now();
     let min = state.preferences.lock().map_err(|e| e.to_string())?.effective_min_brightness();
+    crate::config::write_debug_log(
+        &state,
+        &format!("set_brightness: id={} value={} min={} — START", monitor_id, value, min),
+    );
     state.sidecar_cache.invalidate_monitors();
-    set_monitor_brightness(&monitor_id, value, min).await
+    let result = set_monitor_brightness(&monitor_id, value, min).await;
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    match &result {
+        Ok(ok) => crate::config::write_debug_log(
+            &state,
+            &format!("set_brightness: id={} platform_ok={} — {:.1}ms", monitor_id, ok, elapsed),
+        ),
+        Err(e) => crate::config::write_debug_log(
+            &state,
+            &format!("set_brightness: id={} ERROR={} — {:.1}ms", monitor_id, e, elapsed),
+        ),
+    }
+    match result? {
+        true => Ok(()),
+        false => Err(format!("set_brightness failed for monitor {}", monitor_id)),
+    }
 }
 
 /// Sets brightness for all monitors, enforcing the minimum brightness floor.
@@ -250,26 +272,97 @@ pub async fn set_all_brightness(
     state: tauri::State<'_, crate::AppState>,
     value: u32,
 ) -> Result<(), String> {
+    let t0 = std::time::Instant::now();
     let min = state.preferences.lock().map_err(|e| e.to_string())?.effective_min_brightness();
+    crate::config::write_debug_log(
+        &state,
+        &format!("set_all_brightness: value={} min={} — START", value, min),
+    );
     state.sidecar_cache.invalidate_monitors();
-    set_all_monitors_brightness(value, min).await
+    let result = set_all_monitors_brightness(value, min).await;
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    match &result {
+        Ok(per_monitor) => {
+            let summary = per_monitor.iter()
+                .map(|(id, ok)| format!("{}={}", id, ok))
+                .collect::<Vec<_>>()
+                .join(", ");
+            crate::config::write_debug_log(
+                &state,
+                &format!(
+                    "set_all_brightness: value={} per_monitor=[{}] — {:.1}ms",
+                    value, summary, elapsed,
+                ),
+            );
+        }
+        Err(e) => crate::config::write_debug_log(
+            &state,
+            &format!("set_all_brightness: value={} ERROR={} — {:.1}ms", value, e, elapsed),
+        ),
+    }
+    result.map(|_| ())
 }
 
 /// Sets contrast for a single monitor (0-100, DDC-only).
 #[tauri::command]
 pub async fn set_contrast(
+    state: tauri::State<'_, crate::AppState>,
     monitor_id: String,
     value: u32,
 ) -> Result<(), String> {
-    set_monitor_contrast(&monitor_id, value).await
+    let t0 = std::time::Instant::now();
+    crate::config::write_debug_log(
+        &state,
+        &format!("set_contrast: id={} value={} — START", monitor_id, value),
+    );
+    let result = set_monitor_contrast(&monitor_id, value).await;
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    match &result {
+        Ok(ok) => crate::config::write_debug_log(
+            &state,
+            &format!("set_contrast: id={} platform_ok={} — {:.1}ms", monitor_id, ok, elapsed),
+        ),
+        Err(e) => crate::config::write_debug_log(
+            &state,
+            &format!("set_contrast: id={} ERROR={} — {:.1}ms", monitor_id, e, elapsed),
+        ),
+    }
+    match result? {
+        true => Ok(()),
+        false => Err(format!("set_contrast failed for monitor {}", monitor_id)),
+    }
 }
 
 /// Sets contrast for all monitors (0-100, DDC-only).
 #[tauri::command]
 pub async fn set_all_contrast(
+    state: tauri::State<'_, crate::AppState>,
     value: u32,
 ) -> Result<(), String> {
-    set_all_monitors_contrast(value).await
+    let t0 = std::time::Instant::now();
+    crate::config::write_debug_log(
+        &state,
+        &format!("set_all_contrast: value={} — START", value),
+    );
+    let result = set_all_monitors_contrast(value).await;
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    match &result {
+        Ok(per_monitor) => {
+            let summary = per_monitor.iter()
+                .map(|(id, ok)| format!("{}={}", id, ok))
+                .collect::<Vec<_>>()
+                .join(", ");
+            crate::config::write_debug_log(
+                &state,
+                &format!("set_all_contrast: value={} per_monitor=[{}] — {:.1}ms", value, summary, elapsed),
+            );
+        }
+        Err(e) => crate::config::write_debug_log(
+            &state,
+            &format!("set_all_contrast: value={} ERROR={} — {:.1}ms", value, e, elapsed),
+        ),
+    }
+    result.map(|_| ())
 }
 
 /// Updates a monitor's custom label in preferences. Creates a new metadata entry

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,59 @@ mod volume;
 mod wallpaper;
 
 use chrono::Timelike;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
 use tauri_plugin_autostart::ManagerExt;
+
+/// Tracks whether we've already written the one-time startup dump to the debug log.
+/// Set on the first successful `fetch_all_state` call so subsequent calls are quiet.
+static STARTUP_DUMP_WRITTEN: AtomicBool = AtomicBool::new(false);
+
+/// Writes a comprehensive snapshot to the debug log the first time the frontend
+/// fetches state after launch. Anchors every subsequent debug-log line to a known
+/// baseline: app version, OS+arch, monitor enumeration with DDC support per panel,
+/// and the platform-layer `debug_info` JSON (HMONITOR list, raw VCP brightness/
+/// contrast reads, DDC enumerate error, WMI brightness). Critical for diagnosing
+/// "slider moves but hardware doesn't" symptoms: the JSON shows whether DDC reads
+/// even succeeded for each panel before we tried any writes.
+fn write_startup_dump(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    if STARTUP_DUMP_WRITTEN.swap(true, Ordering::Relaxed) {
+        return; // already wrote it
+    }
+    let state = match app.try_state::<AppState>() {
+        Some(s) => s,
+        None => return,
+    };
+
+    let mut lines: Vec<String> = Vec::new();
+    lines.push("=== STARTUP DUMP (first fetch_all_state) ===".into());
+    lines.push(format!("version: {}", config::get_app_version()));
+    lines.push(format!("os: {} {}", std::env::consts::OS, std::env::consts::ARCH));
+    lines.push(format!("backend: in-process (display-dj-cli vendored)"));
+
+    // Live enumerate — same code path the brightness slider hits.
+    let displays = crate::core::display::list_all();
+    lines.push(format!("--- core::display::list_all ({} displays) ---", displays.len()));
+    for d in &displays {
+        lines.push(format!(
+            "  id={} type={} ddc_supported={} brightness={:?} contrast={:?} name={:?}",
+            d.id, d.display_type, d.ddc_supported, d.brightness, d.contrast, d.name,
+        ));
+    }
+
+    // Raw platform diagnostics — HMONITOR mapping, DDC enumerate result,
+    // per-monitor VCP brightness/contrast (current+max), WMI brightness.
+    lines.push("--- platform debug_info ---".into());
+    let platform_dbg = <crate::core::PlatformImpl as crate::core::Platform>::debug_info();
+    match serde_json::to_string_pretty(&platform_dbg) {
+        Ok(s) => lines.push(s),
+        Err(e) => lines.push(format!("(serialize failed: {})", e)),
+    }
+    lines.push("=== END STARTUP DUMP ===".into());
+
+    config::write_debug_log(&state, &lines.join("\n"));
+}
 
 /// Stub tiling commands for platforms without tiling support (e.g. FreeBSD).
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
@@ -53,6 +104,10 @@ async fn fetch_all_state(
 ) -> Result<AllState, String> {
     use tauri::Manager;
     let t0 = std::time::Instant::now();
+    // One-time per-launch dump: version, OS, full live monitor enumeration,
+    // platform debug_info JSON. Anchors every later debug-log line to a known
+    // baseline so we don't have to ask "what does the hardware look like".
+    write_startup_dump(&app);
     if let Some(s) = app.try_state::<AppState>() {
         config::write_debug_log(&s, "benchmark: fetch_all_state — START");
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -870,6 +870,27 @@ fn dump_debug_info(app: &AppHandle) {
         }
     }
 
+    // Live hardware probe — exercises the same code path the brightness slider
+    // uses, so we can tell whether DDC enumerate/get/set succeed for each panel.
+    // Mirrors the rich diagnostics the standalone display-dj-cli used to print.
+    lines.push("--- live displays (core::display::list_all) ---".into());
+    for d in crate::core::display::list_all() {
+        lines.push(format!(
+            "  id={} type={} ddc_supported={} brightness={:?} contrast={:?} name={:?}",
+            d.id, d.display_type, d.ddc_supported, d.brightness, d.contrast, d.name
+        ));
+    }
+
+    // Raw platform diagnostics — HMONITOR mapping, DDC enumerate result,
+    // per-monitor VCP brightness/contrast (current+max), WMI brightness.
+    // This is what lets us diagnose silent DDC failures on a specific panel.
+    lines.push("--- platform debug_info ---".into());
+    let platform_dbg = <crate::core::PlatformImpl as crate::core::Platform>::debug_info();
+    match serde_json::to_string_pretty(&platform_dbg) {
+        Ok(s) => lines.push(s),
+        Err(e) => lines.push(format!("(serialize failed: {})", e)),
+    }
+
     lines.push("=== END DEBUG INFO ===".into());
     let output = lines.join("\n");
     log::info!("{}", output);

--- a/src-tauri/src/volume.rs
+++ b/src-tauri/src/volume.rs
@@ -38,8 +38,15 @@ pub async fn get_volume(
 /// Updates the cached is_muted state and refreshes the tray icon.
 #[tauri::command]
 pub async fn set_volume(value: u32, app: tauri::AppHandle) -> Result<(), String> {
+    let t0 = std::time::Instant::now();
     let clamped = value.min(100);
-    log::info!("set_volume: value={}", clamped);
+    log::info!("set_volume: value={} clamped={}", value, clamped);
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        crate::config::write_debug_log(
+            &state,
+            &format!("set_volume: value={} clamped={} — START", value, clamped),
+        );
+    }
     let ok = tauri::async_runtime::spawn_blocking(move || {
         crate::core::volume::set_volume(clamped as u16)
     })
@@ -48,10 +55,15 @@ pub async fn set_volume(value: u32, app: tauri::AppHandle) -> Result<(), String>
     if !ok {
         log::warn!("set_volume: platform layer reported failure");
     }
-    log::info!("set_volume: done");
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    log::info!("set_volume: done platform_ok={} elapsed={:.1}ms", ok, elapsed);
     // Invalidate cache since volume changed
     if let Some(state) = app.try_state::<crate::AppState>() {
         state.sidecar_cache.invalidate_volume();
+        crate::config::write_debug_log(
+            &state,
+            &format!("set_volume: value={} platform_ok={} — {:.1}ms", clamped, ok, elapsed),
+        );
     }
     crate::tray_icon::set_muted_state(&app, clamped == 0);
     Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-docs/refs/heads/main/schemas/config.schema.json",
   "productName": "Display DJ",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "identifier": "com.synle.display-dj",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Symptom reported on a Windows 11 mixed-DPI setup (USB-C 4K external + laptop, 2.5x / 1.0x scale): brightness slider moves but the SDC416B external panel does not visibly change. The current `debug.log` shows monitor configs but **none of the platform-level state** needed to diagnose silent DDC failures (was DDC enumerate OK? did `vcp_brightness` raw read succeed? did `SetVCPFeature` return Err?). This PR fills that gap.

This is **instrumentation only** — no behavior change to brightness, contrast, dark-mode, or volume code paths. Adds:

- **One-time startup dump** on first `fetch_all_state` per launch — version, OS, `core::display::list_all` per panel, full platform `debug_info` JSON (HMONITOR list, DDC raw VCP brightness/contrast, DDC enumerate error, WMI brightness).
- **`Tray → Debug → Dump Debug Info`** now also includes the live displays section and the platform `debug_info` JSON.
- **Per-Tauri-command `write_debug_log`** for `set_brightness`, `set_all_brightness`, `set_contrast`, `set_all_contrast`, `set_dark_mode`, `set_volume` — input value, clamped value, platform return, per-monitor success/failure for the "all" variants, elapsed ms.
- **`log::info!` inside `core::windows`** at the actual DDC/gamma/WMI write sites — `set_brightness` (ddc_supported, use_ddc, use_gamma, ddc_attempted, ddc_ok, raw ddc_err, return_ok), `set_contrast` (return_ok, raw err), `wmi_set` (return_ok, PowerShell stderr). These surface in stderr (env_logger) and are visible in `tauri dev` console.

## Why this matters for the SDC416B bug

The new lines will make the next debug log self-diagnosing. Specifically the JSON dump will say whether `ddc_monitors[1].vcp_brightness.current` is `null` (DDC genuinely failing on that panel) or a number (DDC reads work but writes return Err — different fix). The per-call `set_brightness[external]:` line will pin down DDC vs gamma vs both.

## Surface area

| File | Change |
|---|---|
| `src-tauri/src/lib.rs` | `write_startup_dump` + AtomicBool gate + call from `fetch_all_state` |
| `src-tauri/src/tray.rs` | `dump_debug_info` appends live displays + platform `debug_info` JSON |
| `src-tauri/src/display.rs` | inner helpers return `bool` / `Vec<(String, bool)>`; Tauri command wrappers `write_debug_log` start/end with per-monitor results; `set_contrast` / `set_all_contrast` gain `state: State<'_, AppState>` |
| `src-tauri/src/dark_mode.rs` | `set_dark_mode` writes debug log on START + end |
| `src-tauri/src/volume.rs` | `set_volume` writes debug log on START + end |
| `src-tauri/src/core/windows.rs` | `log::info!` inside `ExternalControl::{set_brightness, set_contrast}` and `BuiltinControl::wmi_set` |
| `src-tauri/tauri.conf.json` | 7.0.9 → 7.0.10 |

## Local patch note

`core/windows.rs` is vendored from `display-dj-cli`. The `log::info!` additions are a display-dj-local patch (same pattern as the `hidden_command` substitution). On the next vendor refresh either re-apply manually or cross-apply upstream.

## Test plan

- [x] `cd src-tauri && cargo test --lib` — 236 passed
- [x] `npm test` — 115 passed
- [x] `cargo check` — clean (only pre-existing warnings)
- [ ] CI: build.yml across macOS ARM/Intel, Windows, Linux
- [ ] Manual: on broken Windows setup, toggle Debug Logging on → restart → open popup → drag external brightness slider → confirm `=== STARTUP DUMP ===` + `set_brightness` per-monitor lines + `set_brightness[external]:` stderr lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)