### PR TITLE
fix(windows): explicit DDC/HMONITOR pairing + About v-prefix (v7.0.11)

### DIFF
--- a/VENDORING.md
+++ b/VENDORING.md
@@ -24,16 +24,16 @@ The "Last-synced SHA" column records the upstream `synle/display-dj-cli`
 commit on `main` that each vendored snapshot corresponds to. Run
 `./scripts/check-vendor-drift.sh` to verify these are still accurate.
 
-| Vendored path                     | Upstream path    | Last-synced SHA | Notes                                                                                                                                                                  |
-| --------------------------------- | ---------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src-tauri/src/core/mod.rs`       | `src/main.rs`    | `3b9306d`       | Extracted shared types (`DisplayInfo`, `DisplayControl`, `Platform`, VCP consts, `matches_display`) + added `PlatformImpl` cfg-alias.                                  |
-| `src-tauri/src/core/macos.rs`     | `src/macos.rs`   | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                  |
-| `src-tauri/src/core/windows.rs`   | `src/windows.rs` | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                  |
-| `src-tauri/src/core/linux.rs`     | `src/linux.rs`   | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                  |
-| `src-tauri/src/core/theme.rs`     | `src/main.rs`    | `3b9306d`       | Extracted `get_dark_mode` / `set_dark_mode` per-OS impls (macOS AppleScript, Windows registry, Linux gsettings/dconf).                                                 |
-| `src-tauri/src/core/volume.rs`    | `src/main.rs`    | `3b9306d`       | Extracted `get_volume` / `set_volume` / `set_mute` per-OS impls + `VolumeInfo`.                                                                                        |
-| `src-tauri/src/core/wallpaper.rs` | `src/main.rs`    | `3b9306d`       | Extracted `set_wallpaper` / `set_wallpaper_one` per-OS impls + `SlideshowState` and `slideshow_*` helpers.                                                             |
-| `src-tauri/src/core/display.rs`   | `src/main.rs`    | `3b9306d`       | Distilled high-level fan-out helpers (`list_all`, `set_all_brightness`, `set_one_brightness`, contrast variants) from CLI's `cmd_get` / `cmd_set_all` / `cmd_set_one`. |
+| Vendored path                     | Upstream path    | Last-synced SHA | Notes                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------- | ---------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src-tauri/src/core/mod.rs`       | `src/main.rs`    | `3b9306d`       | Extracted shared types (`DisplayInfo`, `DisplayControl`, `Platform`, VCP consts, `matches_display`) + added `PlatformImpl` cfg-alias.                                                                                                                                                                                 |
+| `src-tauri/src/core/macos.rs`     | `src/macos.rs`   | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                                                                                                                                                                 |
+| `src-tauri/src/core/windows.rs`   | `src/windows.rs` | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                                                                                                                                                                 |
+| `src-tauri/src/core/linux.rs`     | `src/linux.rs`   | `3b9306d`       | Copied 1:1; only adjustment is `crate::` → `super::`.                                                                                                                                                                                                                                                                 |
+| `src-tauri/src/core/theme.rs`     | `src/main.rs`    | `3b9306d`       | Extracted `get_dark_mode` / `set_dark_mode` per-OS impls (macOS AppleScript, Windows registry, Linux gsettings/dconf).                                                                                                                                                                                                |
+| `src-tauri/src/core/volume.rs`    | `src/main.rs`    | `3b9306d`       | Extracted `get_volume` / `set_volume` / `set_mute` per-OS impls + `VolumeInfo`.                                                                                                                                                                                                                                       |
+| `src-tauri/src/core/wallpaper.rs` | `src/main.rs`    | `3b9306d`       | Extracted `set_wallpaper` / `set_wallpaper_one` per-OS impls + `SlideshowState` and `slideshow_*` helpers.                                                                                                                                                                                                            |
+| `src-tauri/src/core/display.rs`   | `src/main.rs`    | `3b9306d`       | Distilled high-level fan-out helpers (`list_all`, `set_all_brightness`, `set_one_brightness`, contrast variants) from CLI's `cmd_get` / `cmd_set_all` / `cmd_set_one`.                                                                                                                                                |
 | `src-tauri/src/core/win_cmd.rs`   | _(local)_        | _n/a_           | display-dj-only helper. Wraps `Command::new(...)` with the Win32 `CREATE_NO_WINDOW` (`0x08000000`) creation flag so `powershell` / `reg` spawns don't flash a console window on every brightness/volume/theme/wallpaper change. Has no upstream counterpart — the CLI is itself a console app, so it never needed it. |
 
 In addition to the table above, the following vendored files carry a
@@ -45,6 +45,18 @@ display-dj-local Windows patch on top of their upstream snapshot:
 binary does not pop a console window for each child spawn. When
 re-syncing from upstream, re-apply these substitutions or run a
 follow-up `s/std::process::Command::new("\(powershell\|reg\)")/hidden_command("\1")/g` pass.
+
+`src-tauri/src/core/windows.rs` also carries a display-dj-local fix to
+the DDC enumeration path (v7.0.11): instead of calling
+`ddc_winapi::Monitor::enumerate()` and zipping the resulting Vec with
+`enum_hmonitors()` by index, the code now iterates HMONITORs once and
+calls `ddc_winapi::get_physical_monitors_from_hmonitor(hm)` per
+HMONITOR — explicit pairing, no implicit index alignment between two
+independent `EnumDisplayMonitors` calls. Both `WinPlatform::enumerate`
+and `WinPlatform::debug_info` use this strategy; `debug_info` also
+emits `hmonitor_index` on each DDC entry so the diagnostic dump
+anchors DDC results to specific physical displays. On the next vendor
+refresh, re-apply this change (or push it upstream).
 
 The recorded SHAs above reflect the latest upstream commit at which
 the vendored snapshots are byte-identical (modulo the

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -800,7 +800,8 @@ pub fn get_about_info() -> std::collections::HashMap<String, String> {
     };
     let mut info = std::collections::HashMap::new();
     info.insert("version".into(), env!("APP_VERSION").to_string());
-    info.insert("engine".into(), "Tauri + Rust Sidecar".to_string());
+    // v7.0.0+ has no sidecar — platform code is vendored in-process under src/core/.
+    info.insert("engine".into(), "Tauri + Rust (in-process)".to_string());
     info.insert("arch".into(), arch.to_string());
     info.insert("os".into(), os.to_string());
     info.insert("buildDate".into(), env!("BUILD_DATE").to_string());

--- a/src-tauri/src/core/windows.rs
+++ b/src-tauri/src/core/windows.rs
@@ -10,6 +10,15 @@ use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use winapi::um::wingdi::SetDeviceGammaRamp;
 
+/// Cast a `windows::Win32::Graphics::Gdi::HMONITOR` (raw pointer wrapped in a
+/// tuple struct) to the `winapi::shared::windef::HMONITOR` type expected by
+/// `ddc-winapi` v0.2. Both are opaque-pointer aliases over the same Win32
+/// handle — only the surrounding Rust wrapper type differs. Pulled out as a
+/// helper so the unsafe-looking pointer cast is named and documented.
+fn hmonitor_to_winapi(hm: HMONITOR) -> winapi::shared::windef::HMONITOR {
+    hm.0 as winapi::shared::windef::HMONITOR
+}
+
 // =========================================================================
 // Built-in display — WMI (Windows Management Instrumentation) via PowerShell.
 // Laptops expose brightness through the WmiMonitorBrightness WMI class.
@@ -300,38 +309,70 @@ impl Platform for WinPlatform {
 
         // --- External displays ---
         // We need both DDC handles (for brightness) and HMONITOR handles (for gamma).
-        // These come from different APIs so we zip them together by index:
-        //   - ddc_winapi::Monitor::enumerate() → DDC physical monitor handles (Dxva2)
-        //   - enum_hmonitors() → GDI HMONITOR handles (for gamma ramp)
-        // Both use EnumDisplayMonitors internally, so indices align.
+        // Previously, we called `ddc_winapi::Monitor::enumerate()` and then `zip`'d
+        // the resulting Vec with `enum_hmonitors()` by index — both internally call
+        // `EnumDisplayMonitors`, and the assumption was "callback order is the same".
+        // That assumption was fragile: `EnumDisplayMonitors` is not documented to
+        // return a deterministic order, and a single mismatched index assigns the
+        // wrong DDC handle to a monitor (e.g. SetVCPFeature targets the laptop panel
+        // when the user pulls the slider on the external one, while the GDI gamma
+        // call writes to the correct external HMONITOR — yielding a visible no-op
+        // because the panel that DDC actually accepted the write for is a different
+        // physical screen entirely).
         //
-        // DEDUP: On laptops, the built-in panel appears in both WMI and DDC enumeration.
-        // We track has_builtin to skip the primary HMONITOR from DDC when WMI already
-        // covered it. See "Windows display dedup" in CLAUDE.md for full explanation.
+        // Fix: enumerate HMONITORs once via `enum_hmonitors()`, then for each
+        // HMONITOR call `ddc_winapi::get_physical_monitors_from_hmonitor(hm)` to
+        // get the physical monitor(s) attached to that specific HMONITOR. Wrap
+        // each `PHYSICAL_MONITOR` in `Monitor::new(pm)`. The (DDC handle, HMONITOR)
+        // pairing is now explicit and per-HMONITOR — order can't drift.
+        //
+        // DEDUP: On laptops, the built-in panel appears in both WMI and DDC
+        // enumeration. We track has_builtin to skip the primary HMONITOR from DDC
+        // when WMI already covered it. See "Windows display dedup" in CLAUDE.md.
         let has_builtin = !result.is_empty();
         let hmonitors = enum_hmonitors();
-        // Pre-compute details for each HMONITOR (PnP device ID + primary flag)
         let hmonitor_details: Vec<(String, bool)> = hmonitors.iter()
             .map(|&hm| get_hmonitor_details(hm))
             .collect();
 
-        if let Ok(monitors) = ddc_winapi::Monitor::enumerate() {
-            let mut ext_id = 1usize;
-            for (idx, mut mon) in monitors.into_iter().enumerate() {
-                let hmonitor = hmonitors.get(idx).copied().unwrap_or(HMONITOR::default());
-                let (device_id, is_primary) = hmonitor_details.get(idx)
-                    .cloned()
-                    .unwrap_or((String::new(), false));
+        let mut ext_id = 1usize;
+        for (idx, &hmonitor) in hmonitors.iter().enumerate() {
+            let (device_id, is_primary) = hmonitor_details.get(idx)
+                .cloned()
+                .unwrap_or((String::new(), false));
 
-                // DEDUP: Skip the primary (built-in) monitor if we already added it via WMI.
-                // On laptops, the built-in panel appears in both WMI and DDC enumeration.
-                // Without this check, you'd get a duplicate: the WMI "Built-in Display"
-                // plus a DDC "Generic PnP Monitor" with null brightness (laptop panels
-                // don't respond to DDC commands). The primary HMONITOR flag reliably
-                // identifies the built-in panel across all Windows laptop configurations.
-                if has_builtin && is_primary {
+            // DEDUP: Skip the primary (built-in) monitor if we already added it via WMI.
+            // On laptops, the built-in panel appears in both WMI and DDC enumeration.
+            // Without this check, you'd get a duplicate: the WMI "Built-in Display"
+            // plus a DDC "Generic PnP Monitor" with null brightness (laptop panels
+            // don't respond to DDC commands). The primary HMONITOR flag reliably
+            // identifies the built-in panel across all Windows laptop configurations.
+            if has_builtin && is_primary {
+                continue;
+            }
+
+            // Resolve physical monitors for *this* HMONITOR — explicit pairing,
+            // no implicit index alignment with a separate enumeration call.
+            let physical_monitors = match ddc_winapi::get_physical_monitors_from_hmonitor(
+                hmonitor_to_winapi(hmonitor),
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!(
+                        "GetPhysicalMonitorsFromHMONITOR failed for hmonitor[{}] device_id={:?}: {}",
+                        idx, device_id, e,
+                    );
                     continue;
                 }
+            };
+
+            for pm in physical_monitors {
+                // SAFETY: `pm` came from GetPhysicalMonitorsFromHMONITOR; ddc-winapi
+                // takes ownership of the handle and calls DestroyPhysicalMonitor on
+                // drop. The constructor is unsafe only because the crate cannot
+                // verify the handle is valid; we obtained it from the OS API one
+                // statement ago.
+                let mut mon = unsafe { ddc_winapi::Monitor::new(pm) };
 
                 let brightness = mon.get_vcp_feature(VCP_BRIGHTNESS).ok().map(|val| {
                     let max = val.maximum() as f64;
@@ -395,31 +436,49 @@ impl Platform for WinPlatform {
         }
 
         // --- DDC monitors with raw VCP data ---
+        // Enumerate per-HMONITOR (same pairing strategy as `enumerate()`) so the
+        // `hmonitor_index` field anchors each DDC entry to a specific physical
+        // display in the `hmonitors` array above. Previous code called
+        // `Monitor::enumerate()` and reported a flat index, which made it
+        // impossible to tell which HMONITOR a DDC entry belonged to when
+        // ordering between the two calls drifted.
         let mut ddc_list = Vec::new();
-        let ddc_error: Option<String>;
-        match ddc_winapi::Monitor::enumerate() {
-            Ok(monitors) => {
-                ddc_error = None;
-                for (idx, mut mon) in monitors.into_iter().enumerate() {
-                    let desc = mon.description();
-                    let brightness_raw = mon.get_vcp_feature(VCP_BRIGHTNESS).ok().map(|v| {
-                        serde_json::json!({"current": v.value(), "max": v.maximum()})
-                    });
-                    let contrast_raw = mon.get_vcp_feature(VCP_CONTRAST).ok().map(|v| {
-                        serde_json::json!({"current": v.value(), "max": v.maximum()})
-                    });
-                    ddc_list.push(serde_json::json!({
-                        "index": idx,
-                        "description": desc,
-                        "vcp_brightness": brightness_raw,
-                        "vcp_contrast": contrast_raw,
-                    }));
+        let mut ddc_errors: Vec<String> = Vec::new();
+        let mut ddc_seq = 0usize;
+        for (hm_idx, &hmonitor) in hmonitors.iter().enumerate() {
+            match ddc_winapi::get_physical_monitors_from_hmonitor(hmonitor_to_winapi(hmonitor)) {
+                Ok(physicals) => {
+                    for pm in physicals {
+                        // SAFETY: handle obtained from the OS one line above; ddc-winapi
+                        // takes ownership and calls DestroyPhysicalMonitor on drop.
+                        let mut mon = unsafe { ddc_winapi::Monitor::new(pm) };
+                        let desc = mon.description();
+                        let brightness_raw = mon.get_vcp_feature(VCP_BRIGHTNESS).ok().map(|v| {
+                            serde_json::json!({"current": v.value(), "max": v.maximum()})
+                        });
+                        let contrast_raw = mon.get_vcp_feature(VCP_CONTRAST).ok().map(|v| {
+                            serde_json::json!({"current": v.value(), "max": v.maximum()})
+                        });
+                        ddc_list.push(serde_json::json!({
+                            "index": ddc_seq,
+                            "hmonitor_index": hm_idx,
+                            "description": desc,
+                            "vcp_brightness": brightness_raw,
+                            "vcp_contrast": contrast_raw,
+                        }));
+                        ddc_seq += 1;
+                    }
+                }
+                Err(e) => {
+                    ddc_errors.push(format!("hmonitor[{}]: {}", hm_idx, e));
                 }
             }
-            Err(e) => {
-                ddc_error = Some(format!("{}", e));
-            }
         }
+        let ddc_error: Option<String> = if ddc_errors.is_empty() {
+            None
+        } else {
+            Some(ddc_errors.join("; "))
+        };
 
         serde_json::json!({
             "wmi_brightness": wmi_brightness,

--- a/src-tauri/src/sidecar_cache.rs
+++ b/src-tauri/src/sidecar_cache.rs
@@ -1,10 +1,15 @@
-//! TTL-based cache for sidecar HTTP responses.
+//! TTL-based cache for platform reads.
 //!
-//! Caches the results of `/get_all` (monitors), `/theme` (dark mode), and
-//! `/get_volume` (volume) so that rapid frontend polls don't hit the sidecar
-//! on every call. The TTL is 2 minutes — stale entries trigger a fresh HTTP
-//! call. Writes (set_brightness, set_volume, set_dark_mode, etc.) and Force
-//! Refresh invalidate the relevant cache entries.
+//! Caches the results of `core::PlatformImpl::enumerate()` (monitors),
+//! `core::theme::get_dark_mode()`, and `core::volume::get_volume()` so that
+//! rapid frontend polls don't re-hit the OS APIs on every call. The TTL is
+//! 5 minutes — stale entries trigger a fresh in-process read. Writes
+//! (set_brightness, set_volume, set_dark_mode, etc.) and Force Refresh
+//! invalidate the relevant cache entries.
+//!
+//! Name retained from v6.x (when the cache wrapped HTTP responses from the
+//! sidecar process). v7+ has no sidecar — this is now a pure in-process
+//! cache. See CLAUDE.md "Architecture".
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -25,13 +30,13 @@ impl<T> CacheEntry<T> {
     }
 }
 
-/// Thread-safe cache for sidecar HTTP responses and system state.
+/// Thread-safe cache for platform reads and system state.
 pub struct SidecarCache {
-    /// Cached monitor list (from sidecar /get_all + metadata merge).
+    /// Cached monitor list (from `core::PlatformImpl::enumerate()` + metadata merge).
     monitors: Mutex<Option<CacheEntry<Vec<crate::display::Monitor>>>>,
-    /// Cached dark mode state (from sidecar /theme).
+    /// Cached dark mode state (from `core::theme::get_dark_mode()`).
     dark_mode: Mutex<Option<CacheEntry<bool>>>,
-    /// Cached volume level (from sidecar /get_volume).
+    /// Cached volume level (from `core::volume::get_volume()`).
     volume: Mutex<Option<CacheEntry<u32>>>,
     /// Cached macOS Accessibility permission status (AXIsProcessTrusted).
     accessibility: Mutex<Option<CacheEntry<bool>>>,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-docs/refs/heads/main/schemas/config.schema.json",
   "productName": "Display DJ",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "identifier": "com.synle.display-dj",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/AboutPanel.test.tsx
+++ b/src/components/AboutPanel.test.tsx
@@ -70,6 +70,26 @@ describe('AboutPanel', () => {
     });
   });
 
+  it('strips the leading "v" from the latest release tag for display', async () => {
+    setupMocks({
+      info: { version: '3.1.4', os: 'Linux', arch: 'x64' },
+      currentVersion: '3.1.4',
+      latestTag: 'v3.1.4',
+    });
+    render(<AboutPanel onClose={() => {}} />);
+
+    // Wait for the async fetch to resolve and the badge to appear.
+    await waitFor(() => {
+      expect(screen.getByText('Up to date')).toBeInTheDocument();
+    });
+
+    // The Latest row should render the version without the leading "v" so it
+    // aligns with the Version row ("3.1.4", not "v3.1.4"). Both Version and
+    // Latest cells render the same text — use getAllByText and require ≥ 2 matches.
+    expect(screen.getAllByText('3.1.4').length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText('v3.1.4')).not.toBeInTheDocument();
+  });
+
   it('shows "Update available" badge and download link when latest > current', async () => {
     setupMocks({
       info: { version: '1.0.0', os: 'Linux', arch: 'x64' },
@@ -80,7 +100,7 @@ describe('AboutPanel', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Update available')).toBeInTheDocument();
-      expect(screen.getByText('Download v2.0.0')).toBeInTheDocument();
+      expect(screen.getByText('Download 2.0.0')).toBeInTheDocument();
     });
   });
 

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -33,7 +33,9 @@ function AboutPanel({ onClose }: AboutPanelProps) {
       .then((r) => r.json())
       .then((r) => {
         const tag = r.tag_name || 'unknown';
-        setLatestVersion(tag);
+        // Strip the leading 'v' so "Latest" aligns with "Version" (which has no prefix).
+        const displayTag = tag === 'unknown' ? tag : tag.replace(/^v/, '');
+        setLatestVersion(displayTag);
         return tag;
       })
       .then((tag) => {


### PR DESCRIPTION
## Summary

Three independent fixes bundled per a single user request.

- **About page** — strip the leading `v` from the GitHub release tag so the **Latest** row aligns with the **Version** row (both render `7.0.11`, not `v7.0.11`). Semver comparison still uses the raw tag so update detection is unchanged. Also updated the stale `Tauri + Rust Sidecar` engine label to `Tauri + Rust (in-process)` — v7.0.0 dropped the sidecar; the label was lying.
- **No-server verification** — confirmed v7+ has no sidecar / HTTP server (grep across `src-tauri/` for `SERVER_PORT|externalBin|tauri-plugin-shell|find_available_port` returns 0 hits). Auto-update doesn't need one — `AboutPanel.tsx` queries the public GitHub releases API directly. Refreshed the now-misleading `sidecar_cache.rs` docstring (now a pure in-process cache, name retained from v6.x).
- **Windows external brightness** — explicit DDC ↔ HMONITOR pairing. The previous code called `ddc_winapi::Monitor::enumerate()` and `enum_hmonitors()` independently and zipped them by index, relying on `EnumDisplayMonitors` returning the same callback order across two separate invocations (not documented to be stable). When the orderings drift, `SetVCPFeature` targets the wrong physical monitor while the gamma write goes to the correct HMONITOR — visible no-op on the panel the user is actually adjusting. The fix enumerates HMONITORs once, then per HMONITOR calls `ddc_winapi::get_physical_monitors_from_hmonitor(hm)` and wraps each `PHYSICAL_MONITOR` via `Monitor::new`. Pairing is now explicit. Same strategy applied to `debug_info()`; each DDC entry now carries `hmonitor_index` so future dumps anchor DDC results to specific displays. Documented the local patch in `VENDORING.md` for the next vendor refresh.

## Test plan

- [x] `cd src-tauri && cargo test --lib` — 236 passed
- [x] `npm test` — 116 passed (added regression test for the v-prefix strip)
- [ ] Manual: launch on Windows, open About → confirm Latest renders as `7.0.11` (no leading `v`) and Engine reads `Tauri + Rust (in-process)`.
- [ ] Manual: launch on Windows with mixed-DPI external + laptop, open Dump Debug Info → confirm each `ddc_monitors[*]` entry includes `hmonitor_index` pointing at the matching `hmonitors[*]` row.
- [ ] Manual: drag the external monitor brightness slider, watch the panel actually dim/brighten. If still no movement, the next diagnostic dump will conclusively show whether the SDC416B's `vcp_brightness` is paired with its own HMONITOR (in which case the panel genuinely doesn't expose DDC and we'd need a different write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)