### PR TITLE
WIP: test pre-vendor sidecar against display-dj-cli v2.2.5 (DO NOT MERGE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "display-dj",
   "version": "0.0.0",
   "description": "Cross-platform desktop app for monitor brightness, contrast, and dark mode control",
-  "displayDjCliVersion": "v2.2.2",
+  "displayDjCliVersion": "v2.2.5",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-docs/refs/heads/main/schemas/config.schema.json",
   "productName": "Display DJ",
-  "version": "6.4.7",
+  "version": "7.0.19-sidecar-test.1",
   "identifier": "com.synle.display-dj",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## DO NOT MERGE

This PR is a **binary-verification experiment**. It rolls back to the pre-v7.0.0 sidecar architecture (commit `ef46e84`, v6.4.7) and points at a freshly-released display-dj-cli (`v2.2.5`) to verify that the legacy bridge still works in that configuration.

The vendored-in-process architecture on `main` is the official path; this is testing the legacy bridge purely as a regression sanity check.

## Summary

- Base SHA: `ef46e84` (last commit on v6.4.7 before the v7.0.0 vendor commit `3a7cd42`)
- `package.json` → `displayDjCliVersion`: `v2.2.2` → `v2.2.5`
- `src-tauri/tauri.conf.json` → `version`: `6.4.7` → `7.0.19-sidecar-test.1`
- No other files touched.

## Hard constraints

- **DO NOT MERGE.** Keep this PR draft.
- Companion display-dj-cli release: https://github.com/synle/display-dj-cli/releases/tag/v2.2.5

## Test plan

- [ ] Beta build green on all 6 platforms (macOS arm64/x64, Windows x64/arm64, Linux x64/arm64)
- [ ] Download macOS arm64 `.dmg` from beta release, install, verify brightness slider works
- [ ] Download Windows x64 `_setup.exe` from beta release, install, verify brightness slider works
- [ ] Download Linux x64 `.deb` or `.AppImage` from beta release, verify brightness slider works
- [ ] Confirm sidecar process (`display-dj-server`) is bundled and starts cleanly
- [ ] Confirm sidecar exits when GUI is closed (parent-death detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)