### PR TITLE
feat: built-in keyboard backlight control (beta)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ The Rust backend is split into two layers:
   - `core::macos`, `core::windows`, `core::linux` — per-OS display implementations (DDC/CI, gamma, DisplayServices, WMI, brightnessctl/ddcutil).
   - `core::theme` — system dark mode read/write.
   - `core::volume` — system volume get/set.
+  - `core::keyboard_backlight` — built-in laptop keyboard backlight (beta). macOS via private IOHIDEventSystem, Windows via Lenovo+Dell WMI. Linux unsupported.
   - `core::wallpaper` — wallpaper set + slideshow timer/state/cycling (all in-process).
   - `core::display` — high-level helpers (`set_all_brightness`, `set_one_brightness`, contrast variants) that fan out to `PlatformImpl`.
-- **`src-tauri/src/{display,dark_mode,volume,wallpaper}.rs`** — thin Tauri-command wrappers around `core::*`. CPU-bound work is wrapped in `tauri::async_runtime::spawn_blocking` because every Tauri command taking `State<'_, AppState>` must be `async fn` (see "macOS Tray Icon Pitfall" below).
-- **`src-tauri/src/sidecar_cache.rs`** — 5-minute TTL cache wrapping `core::PlatformImpl::enumerate()`, `core::theme::get_dark_mode()`, and `core::volume::get_volume()` so rapid polls don't re-hit OS APIs. Writes and Force Refresh invalidate. Name retained from the v6.x HTTP-sidecar era; v7+ is pure in-process.
+- **`src-tauri/src/{display,dark_mode,volume,keyboard_backlight,wallpaper}.rs`** — thin Tauri-command wrappers around `core::*`. CPU-bound work is wrapped in `tauri::async_runtime::spawn_blocking` because every Tauri command taking `State<'_, AppState>` must be `async fn` (see "macOS Tray Icon Pitfall" below).
+- **`src-tauri/src/sidecar_cache.rs`** — 5-minute TTL cache wrapping `core::PlatformImpl::enumerate()`, `core::theme::get_dark_mode()`, `core::volume::get_volume()`, and `core::keyboard_backlight::get_keyboard_backlight()`. Writes and Force Refresh invalidate. Name retained from the v6.x HTTP-sidecar era; v7+ is pure in-process.
 - **`src-tauri/src/overlay.rs`** — per-monitor Tauri `WebviewWindow` for soft-overlay brightness fallback (see "Soft-Overlay Brightness Fallback" below).
 
 ## Build Commands
@@ -38,20 +39,7 @@ cargo check          # Check Rust compilation (from src-tauri/)
 
 ## Local Install from Release
 
-Use the `/install-app` slash command to download and install the latest release for the current platform. It handles all platform-specific steps automatically.
-
-### macOS post-install steps (required)
-
-```bash
-xattr -cr "/Applications/Display DJ.app"                       # Strip Apple quarantine (unsigned builds)
-tccutil reset Accessibility com.synle.display-dj               # Reset Accessibility (required after each new build for tiling)
-open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-open "/Applications/Display DJ.app"
-```
-
-### Windows post-install steps
-
-Run the `*_x64-setup.exe` installer — it handles everything.
+Use the `/install-app` slash command — handles platform-specific steps. macOS post-install (unsigned builds): `xattr -cr "/Applications/Display DJ.app"`, then `tccutil reset Accessibility com.synle.display-dj` and grant Accessibility for tiling. Windows: run the `*_x64-setup.exe` installer.
 
 ## Versioning
 
@@ -75,14 +63,16 @@ cd src-tauri && cargo test   # Backend tests (Rust)
 ### Frontend Tests (Vitest + React Testing Library)
 
 - **Setup**: `src/test/setup.ts` — jsdom, jest-dom matchers, Tauri API mocks (`invoke()` and `listen()` mocked globally).
-- **Unit tests**: `src/components/*.test.tsx` — one per component (Header, Slider, DarkModeToggle, VolumeControl, AllMonitorsControl, MonitorControl, KeepAwakeToggle, AboutPanel, ProfileButtons, SettingsPanel).
+- **Unit tests**: `src/components/*.test.tsx` — one per component (Header, Slider, DarkModeToggle, VolumeControl, KeyboardBacklightControl, AllMonitorsControl, MonitorControl, KeepAwakeToggle, AboutPanel, ProfileButtons, SettingsPanel).
 - **Smoke test**: `src/App.test.tsx` — verifies App renders, fetches initial data, handles backend failures.
 
 ### Backend Tests (Rust)
 
 Inline `#[cfg(test)]` modules cover:
 
-- `config.rs`: serde roundtrips, defaults, camelCase, `CommandValue` enum, `MonitorMetadata`, effective min brightness, backward-compatible deserialization, layout presets, night-mode schedules, `WallpaperPreferences`.
+- `config.rs`: serde roundtrips, defaults, camelCase, `CommandValue` enum, `MonitorMetadata`, effective min brightness, backward-compatible deserialization, layout presets, night-mode schedules, `WallpaperPreferences`, `KeyboardBacklightPreferences` + `Shift+F2` combo binding.
+- `core::keyboard_backlight`: `snap_to_25` rounds to nearest 25 + clamps at 100; cross-platform `get` / `set` / `is_supported` smoke tests; back-compat default (`enabled = true`).
+- `keyboard_backlight.rs` (Tauri commands): cache hit/miss, snap-on-set, supported-bool smoke.
 - `display.rs`: `DjDisplay` → `Monitor` conversion (incl. uid). `DjDisplay` is the local conversion struct in `display.rs`; its fields are populated from `core::DisplayInfo`. Also: `merge_with_configs`, `reconcile_migrated_configs`, `ensure_metadata_for_monitors`, `resolve_monitor` (id/uid/substring).
 - `keep_awake.rs`: `KeepAwake` guard creation, `Mutex<Option<KeepAwake>>` enable/disable cycle.
 - `tray_icon.rs`: %-to-px conversion, icon generation across all state combos (dark/light × keep-awake × muted), filled rect/thick line drawing.
@@ -123,19 +113,12 @@ After modifying frontend code (`src/`), config, or docs, always run `npx prettie
 
 ## Windows Console-Flash Pitfall (Critical, Windows-only)
 
-**Every Windows child spawn from a `#[cfg(target_os = "windows")]` code path
-must go through `core::win_cmd::hidden_command(...)`.** That helper returns a
-`std::process::Command` with the Win32 `CREATE_NO_WINDOW` (`0x08000000`)
-creation flag pre-applied, so the short-lived `powershell` / `reg` child does
-not allocate and immediately tear down a console window of its own — which
-otherwise reads as a visible black flash on every brightness change, volume
-change, theme toggle, and wallpaper write (the GUI parent has
-`windows_subsystem = "windows"` and therefore no console to share).
+**Every Windows child spawn from `#[cfg(target_os = "windows")]` must go through `core::win_cmd::hidden_command(...)`.** That helper pre-applies `CREATE_NO_WINDOW` (`0x08000000`) so the short-lived `powershell` / `reg` child doesn't allocate a console (visible black flash on every brightness / volume / theme / wallpaper / keyboard-backlight change — the GUI parent has `windows_subsystem = "windows"` and no console to share).
 
-- **Where this matters**: `core/{windows,volume,theme,wallpaper}.rs`. Every `powershell` / `reg` spawn routes through `hidden_command(...)`. The regression test `no_bare_powershell_or_reg_spawns_in_core` in `lib.rs` fails the build if a bare spawn drifts back in.
-- **Where this does NOT matter**: macOS (osascript) and Linux (gsettings / feh / xfconf-query / xrandr) — no Win32-PE-subsystem concept; a GUI parent launched from `.desktop` / Finder has no controlling terminal so child stdio inherits null fds and no window appears.
-- **The `windows_subsystem` attribute** must live on the binary root (`src-tauri/src/main.rs`), never `lib.rs` — the inner attribute is silently ignored on `lib.rs` and the release `.exe` then ships as a console-subsystem program (`CREATE_NO_WINDOW` on children cannot fix the parent's console).
-- **Cross-apply to upstream**: `core/*` is vendored from `display-dj-cli` (itself a CLI, doesn't need this). The `hidden_command(...)` substitution is a display-dj-local patch — re-apply on vendor refresh; the regression test enforces it.
+- **Where this matters**: `core/{windows,volume,theme,wallpaper,keyboard_backlight}.rs`. Regression test `no_bare_powershell_or_reg_spawns_in_core` in `lib.rs` fails the build if a bare spawn drifts back in.
+- **Not relevant on macOS / Linux** — no Win32-PE-subsystem concept; GUI parents launched from `.desktop` / Finder inherit null stdio.
+- **The `windows_subsystem` attribute** must live on `main.rs`, never `lib.rs` (silently ignored there — release `.exe` then ships as console-subsystem, which `CREATE_NO_WINDOW` on children cannot fix).
+- **Vendor refresh**: `core/*` is vendored from `display-dj-cli` (a CLI — doesn't need this). The `hidden_command` substitution is a display-dj-local patch; re-apply on refresh. Regression test enforces it.
 
 ## macOS Tray Icon Pitfall (Critical)
 
@@ -148,22 +131,7 @@ Inline WARNING comments in `config.rs` document this.
 
 ## Tile Snap Event Monitoring (NSEvent Global Monitor)
 
-Tile Snap uses `NSEvent.addGlobalMonitorForEvents(matching:handler:)` to observe mouse events globally. This replaced `CGEventTap`, which silently failed in production `.app` bundles (macOS Sequoia rejects `CGEventTapEnable` for ad-hoc signed bundles).
-
-**Why NSEvent:**
-
-- Higher-level Cocoa API; macOS trusts it from `.app` bundles without special signing.
-- Listen-only, which is all Tile Snap needs.
-- Handler runs on the main thread automatically.
-
-**Handler rules (main thread):**
-
-1. Keep it fast — defer AX API calls (`get_focused_window`, `get_window_rect`) until the 10px drag threshold is crossed.
-2. Use `try_lock()`, never `lock()`.
-3. Wrap with `catch_unwind` — Rust panics cannot unwind through ObjC blocks (would abort).
-4. Use raw `objc_msgSend` with `Sel::register("type")` for `[event type]` — `type` is a Rust keyword; `msg_send![event, r#type]` raises an ObjC exception.
-5. Convert `[NSEvent mouseLocation]` (Cocoa: Y up from bottom-left) → CG coords (Y down from top-left): `primary_h - cocoa_y`.
-6. Use the `block` crate (v0.1) for ObjC blocks. The block must stay alive (`.copy()` to heap) for the monitor's lifetime.
+Tile Snap uses `NSEvent.addGlobalMonitorForEvents` (listen-only, main-thread, trusted from ad-hoc-signed `.app` bundles — replaces `CGEventTap`, which silently failed under macOS Sequoia). Handler must: stay fast (defer AX calls until the 10 px drag threshold), use `try_lock()` only, wrap in `catch_unwind` (panics can't unwind through ObjC blocks), call `[event type]` via raw `objc_msgSend` + `Sel::register("type")` (`type` is a Rust keyword), and convert Cocoa Y-up coords to CG Y-down via `primary_h - cocoa_y`. Uses the `block` crate (v0.1); the block must outlive the monitor (`.copy()` to heap).
 
 ## Soft-Overlay Brightness Fallback
 
@@ -171,34 +139,20 @@ Some panels (e.g. Samsung Smart Monitor M7/M8 over USB-C on Intel Iris Xe) ignor
 
 ### Per-monitor `brightnessMode` preference
 
-Stored on `MonitorMetadata` in `preferences.monitor_configs`. Four values:
-
-- **`"auto"`** (default) — try DDC, then gamma, then fall back to the overlay if both hardware paths failed.
-- **`"ddc"`** — DDC/CI only, no overlay fallback.
-- **`"gamma"`** — `SetDeviceGammaRamp` only, no overlay fallback.
-- **`"overlay"`** — skip hardware entirely; dim with the overlay window. The only mode that works on the failing-panel scenario above.
-
-The dropdown is rendered next to the existing "Hide" button in Settings (`SettingsPanel.tsx`); built-in displays don't get the dropdown (they dim natively via DisplayServices / WMI / sysfs backlight).
+Stored on `MonitorMetadata.brightnessMode`. Four values: `"auto"` (default — DDC → gamma → overlay), `"ddc"`, `"gamma"`, `"overlay"` (skip hardware, dim via overlay window — only mode that works on USB-C Samsung Smart Monitors on Intel Iris Xe). Dropdown in `SettingsPanel.tsx` next to "Hide"; built-in displays don't get the dropdown (they dim natively via DisplayServices / WMI / sysfs backlight).
 
 ### Overlay module (`src-tauri/src/overlay.rs`)
 
-One Tauri `WebviewWindow` per external monitor, labeled `overlay-{monitor_id}`. Created lazily on the first overlay request, positioned to the monitor's `DisplayInfo.monitor_rect`, made click-through with `set_ignore_cursor_events(true)`. The content is `public/overlay.html` — a single full-viewport black div listening for `set-overlay-alpha` events. Alpha is `1.0 - brightness/100`, clamped to `[0.0, 0.9]` so the user can never make the panel fully opaque (which would prevent recovery via the slider).
+One Tauri `WebviewWindow` per external monitor, labeled `overlay-{monitor_id}`. Lazy-created on first request, positioned via `DisplayInfo.monitor_rect`, click-through (`set_ignore_cursor_events(true)`). Content is `public/overlay.html` — a full-viewport black div listening for `set-overlay-alpha` events. Alpha = `1.0 - brightness/100`, clamped to `[0.0, 0.9]` (so the user can always recover via the slider). API: `overlay::set_overlay_brightness(app, monitor_id, monitor_rect, brightness_pct)` and `overlay::destroy_overlay(app, monitor_id)`.
 
-Public API:
+### Routing
 
-- `overlay::set_overlay_brightness(app, monitor_id, monitor_rect, brightness_pct)` — ensure window, show, emit alpha. Hides instead of showing when `brightness_pct >= 100`.
-- `overlay::destroy_overlay(app, monitor_id)` — close the overlay (called on unplug or when switching back to a hardware-only mode).
-
-### Routing (`display::set_brightness` / `display::set_all_brightness`)
-
-Each Tauri brightness command snapshots `min_brightness`, the per-monitor `brightnessMode`, and the cached `monitor_rect` _before_ awaiting (mutex must not be held across `.await` — see macOS Tray Icon Pitfall). It dispatches through `display::route_for_mode(...)` to one of: `DdcOnly` / `GammaOnly` (call `core::display::set_one_brightness` with the named backend, destroy overlay first), `OverlayOnly` (overlay only, no hardware), or `AutoWithOverlayFallback` (try `"force"`; on failure fall back to overlay).
-
-`set_all_brightness` keeps a fast path for the common all-auto case (bulk `set_all_brightness("force")` + per-monitor overlay touch-up). The same routing is reused by `tray::execute_command` for `command/changeBrightness/...` via `dispatch_brightness_for_{one,all}` helpers.
+Each Tauri brightness command snapshots `min_brightness`, the per-monitor `brightnessMode`, and the cached `monitor_rect` _before_ awaiting (mutex must not be held across `.await` — see macOS Tray Icon Pitfall). Dispatches through `display::route_for_mode(...)` to `DdcOnly` / `GammaOnly` / `OverlayOnly` / `AutoWithOverlayFallback`. The same routing is reused by `tray::execute_command` via `dispatch_brightness_for_{one,all}` helpers.
 
 ### Platform status
 
-- **Windows**: fully functional. `DisplayInfo.monitor_rect` is populated from `MONITORINFOEXW.rcMonitor` for external displays.
-- **macOS / Linux**: the Tauri overlay window itself spawns, but `monitor_rect` is currently `None` on both platforms (see TODOs in `core::macos` and `core::linux`). `brightnessMode = "overlay"` is selectable in the UI but no-ops on those platforms until the rect is filled in. The auto path keeps working on macOS/Linux because DDC and DisplayServices/ddcutil paths are unaffected.
+- **Windows**: fully functional. `DisplayInfo.monitor_rect` from `MONITORINFOEXW.rcMonitor`.
+- **macOS / Linux**: overlay window spawns, but `monitor_rect` is currently `None` (see TODOs). `brightnessMode = "overlay"` is selectable but no-ops on those platforms until the rect is filled in. Auto path unaffected (DDC + DisplayServices / ddcutil still work).
 
 ## Key Conventions
 
@@ -210,6 +164,17 @@ Each Tauri brightness command snapshots `min_brightness`, the per-monitor `brigh
 - Brightness is clamped to `[effective_min_brightness(), 100]` (absolute floor of 5).
 - Contrast is DDC-only (`Option<u32>` / `number | null`); the slider is hidden by default and toggled via `showContrast` in Settings.
 - Keep Awake uses the `keepawake` crate (v0.6) — guard stored as `Mutex<Option<KeepAwake>>` in `AppState`. Creating enables; dropping (set to `None`) releases. Works on macOS (IOKit), Windows (`SetThreadExecutionState`), Linux (D-Bus). The `set_keep_awake` command is `async` (tray pitfall).
+
+## Keyboard Backlight (beta)
+
+Built-in laptop keyboard backlight slider rendered directly below the volume slider. Slider is `step=25` so the only reachable values are **0 / 25 / 50 / 75 / 100**; the backend re-snaps via `core::keyboard_backlight::snap_to_25()` so the shortcut command (`command/changeKeyboardBacklight/{value}`) and the slider produce identical hardware state.
+
+- **macOS**: IOKit `IOHIDEventSystemClient` + `KeyboardBacklightBrightness` property on the service with HID page `0x0B` / usage `0x4B`. Symbols loaded via `dlopen("/System/Library/Frameworks/IOKit.framework/IOKit")` so a future SDK rename degrades to `is_supported() = false` instead of failing to link. Built-in keyboards only.
+- **Windows**: probes Lenovo WMI (`Lenovo_KeyboardBacklightLevel` / `Lenovo_SetKeyboardBacklightLevel` in `root\wmi`) then Dell WMI (`DellKeyboardBacklight`). Vendor 0/1/2 levels map to 0/50/100 %. All spawns route through `core::win_cmd::hidden_command` (console-flash rule).
+- **Linux**: unsupported. Sysfs (`/sys/class/leds/*::kbd_backlight/`) and UPower D-Bus are future work — out of scope for v7.0.26.
+- **External keyboards**: not supported. No Razer / Corsair / Logitech SDK integration.
+
+UI hides the slider when **either** the backend reports unsupported **or** `preferences.keyboardBacklight.enabled = false`. Default keybinding: `Shift+F2` is a `CommandValue::Multiple` that runs both `command/changeProfile/2` (Focus) and `command/changeKeyboardBacklight/0` — a single "dim everything" shortcut.
 
 ## Dynamic Tray Icon (`tray_icon.rs`)
 
@@ -342,6 +307,7 @@ Commands are strings dispatched by `execute_command()` in `tray.rs`. Bindable to
 | `command/changeContrast/{value}`                          | `core::display::set_all_contrast(value)`                    | Set contrast on all monitors                   |
 | `command/changeContrast/{monitor_id}/{value}`             | `core::display::set_one_contrast(id, value)`                | Set contrast on a single monitor               |
 | `command/changeVolume/{value}`                            | `core::volume::set_volume(value)`                           | Set volume (0-100)                             |
+| `command/changeKeyboardBacklight/{value}`                 | `core::keyboard_backlight::set_keyboard_backlight(value)`   | Set keyboard backlight (snapped to nearest 25) |
 | `command/changeDarkMode/dark`                             | `core::theme::set_dark_mode(true)`                          | Switch to dark mode                            |
 | `command/changeDarkMode/light`                            | `core::theme::set_dark_mode(false)`                         | Switch to light mode                           |
 | `command/changeDarkMode/toggle`                           | `core::theme::get_dark_mode()` then `set_dark_mode(!cur)`   | Toggle dark/light mode                         |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,8 @@ display-dj2/
 │       ├── MonitorControl.test.tsx
 │       ├── VolumeControl.tsx     # Volume slider
 │       ├── VolumeControl.test.tsx
+│       ├── KeyboardBacklightControl.tsx     # Keyboard backlight slider (beta, snapped to 25%)
+│       ├── KeyboardBacklightControl.test.tsx
 │       ├── DarkModeToggle.tsx    # Dark / Light toggle buttons
 │       ├── DarkModeToggle.test.tsx
 │       ├── SettingsPanel.tsx     # In-app settings: min brightness, show contrast, night mode schedule, layout presets, wallpaper
@@ -145,11 +147,13 @@ display-dj2/
 │       │   ├── linux.rs          # Linux ddcutil + brightnessctl
 │       │   ├── theme.rs          # Cross-platform dark mode get/set
 │       │   ├── volume.rs         # Cross-platform volume get/set
+│       │   ├── keyboard_backlight.rs  # Keyboard backlight (beta) — macOS IOHIDEventSystem, Windows Lenovo+Dell WMI
 │       │   ├── wallpaper.rs      # Wallpaper set + slideshow timer/state/cycling
 │       │   └── display.rs        # set_all_brightness / set_one_brightness + contrast variants
 │       ├── display.rs            # Tauri-command wrappers around core::display (+ unit tests). Uses spawn_blocking
 │       ├── dark_mode.rs          # Tauri-command wrappers around core::theme
 │       ├── volume.rs             # Tauri-command wrappers around core::volume
+│       ├── keyboard_backlight.rs # Tauri-command wrappers around core::keyboard_backlight
 │       ├── wallpaper.rs          # Tauri-command wrappers around core::wallpaper (incl. remote-pack download via reqwest)
 │       ├── config.rs             # Preferences + monitor metadata persistence, NightModeSchedule, layout presets, min brightness, reset to defaults (+ unit tests)
 │       ├── tray.rs               # System tray menu, window positioning, keyboard shortcut dispatch (in-process command execution)
@@ -478,19 +482,20 @@ When raising thresholds: measure current %, set the floor ~10pp below, update bo
 
 Test files live next to the components they test (`*.test.tsx`).
 
-| File                                         | What it covers                                                                                                             |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `src/components/Header.test.tsx`             | Title rendering, version display, settings button, chevron state                                                           |
-| `src/components/Slider.test.tsx`             | Range input rendering, debounced onChange (150ms), fill width calculation, prop updates                                    |
-| `src/components/DarkModeToggle.test.tsx`     | Active button state, click handlers for dark/light                                                                         |
-| `src/components/VolumeControl.test.tsx`      | Slider value, muted/unmuted icon switching                                                                                 |
-| `src/components/AllMonitorsControl.test.tsx` | Brightness slider, contrast slider visibility, icon-click toggles, monitor count, expand callback                          |
-| `src/components/MonitorControl.test.tsx`     | Monitor name rendering, inline edit mode (Enter/Escape), brightness slider, built-in vs external icons                     |
-| `src/components/KeepAwakeToggle.test.tsx`    | Toggle button state, on/off labels, click handlers                                                                         |
-| `src/components/ProfileButtons.test.tsx`     | Profile rendering, activation callbacks, empty-list handling                                                               |
-| `src/components/AboutPanel.test.tsx`         | Version display, update-available badge, GitHub release fetch, platform-specific commands                                  |
-| `src/components/SettingsPanel.test.tsx`      | Debounced auto-save, preference round-trip, profile editing, layout-preset CRUD                                            |
-| `src/App.test.tsx`                           | **Smoke test**: App mounts without crashing, fetches initial data, renders all sections, handles backend errors gracefully |
+| File                                               | What it covers                                                                                                             |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `src/components/Header.test.tsx`                   | Title rendering, version display, settings button, chevron state                                                           |
+| `src/components/Slider.test.tsx`                   | Range input rendering, debounced onChange (150ms), fill width calculation, prop updates                                    |
+| `src/components/DarkModeToggle.test.tsx`           | Active button state, click handlers for dark/light                                                                         |
+| `src/components/VolumeControl.test.tsx`            | Slider value, muted/unmuted icon switching                                                                                 |
+| `src/components/KeyboardBacklightControl.test.tsx` | Slider value + step=25 snap, ⌨ icon click toggles 0 ↔ 100                                                                  |
+| `src/components/AllMonitorsControl.test.tsx`       | Brightness slider, contrast slider visibility, icon-click toggles, monitor count, expand callback                          |
+| `src/components/MonitorControl.test.tsx`           | Monitor name rendering, inline edit mode (Enter/Escape), brightness slider, built-in vs external icons                     |
+| `src/components/KeepAwakeToggle.test.tsx`          | Toggle button state, on/off labels, click handlers                                                                         |
+| `src/components/ProfileButtons.test.tsx`           | Profile rendering, activation callbacks, empty-list handling                                                               |
+| `src/components/AboutPanel.test.tsx`               | Version display, update-available badge, GitHub release fetch, platform-specific commands                                  |
+| `src/components/SettingsPanel.test.tsx`            | Debounced auto-save, preference round-trip, profile editing, layout-preset CRUD                                            |
+| `src/App.test.tsx`                                 | **Smoke test**: App mounts without crashing, fetches initial data, renders all sections, handles backend errors gracefully |
 
 **Tauri API mocking**: `src/test/setup.ts` globally mocks `invoke()` and `listen()` from `@tauri-apps/api` so tests run without a Tauri backend. The App smoke test provides per-command mock responses.
 

--- a/DEV.md
+++ b/DEV.md
@@ -1,6 +1,6 @@
 # display-dj
 
-Cross-platform desktop app for monitor brightness, contrast, dark mode, volume, and window tiling control. Built with Tauri v2 (Rust backend) and React 19 + TypeScript + Vite 6 (WebView frontend). All platform code (DDC/CI, gamma, WMI, DisplayServices, wallpaper) is vendored in-process under `src-tauri/src/core/`.
+Cross-platform desktop app for monitor brightness, contrast, dark mode, volume, **keyboard backlight (beta)**, and window tiling control. Built with Tauri v2 (Rust backend) and React 19 + TypeScript + Vite 6 (WebView frontend). All platform code (DDC/CI, gamma, WMI, DisplayServices, wallpaper, IOHIDEventSystem / vendor-WMI keyboard backlight) is vendored in-process under `src-tauri/src/core/`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A cross-platform desktop system tray app for controlling monitor brightness, con
 - **Contrast control** -- DDC/CI contrast adjustment for external monitors (enable in Settings)
 - **Dark mode toggle** -- system-wide dark/light mode switch
 - **Volume control** -- system volume slider with mute indicator
+- **Keyboard backlight (beta)** -- built-in laptop keyboard backlight slider snapped to 25% increments. macOS via IOHIDEventSystem (built-in keyboards) and Windows via Lenovo / Dell WMI. Auto-hides on unsupported devices; master enable/disable in Settings. Default `Shift+F2` dims the backlight to 0 alongside the Focus profile
 - **Keep Awake** -- prevent your system from sleeping with a single toggle (macOS, Windows, Linux)
 - **Night mode schedule** -- automatically set brightness and dark/light mode on a time-based schedule (e.g., dim at 9 PM, bright at 7 AM). Supports custom commands (`nightCommands`/`dayCommands`) to run arbitrary actions on schedule (volume changes, profile activation, per-monitor brightness)
 - **Profiles** -- save and restore preset combinations of brightness, contrast, dark mode, and volume
@@ -116,13 +117,13 @@ The main config file is **`preferences.json`** -- it holds keyboard shortcuts, m
 
 ### Default Keyboard Shortcuts
 
-| Keys            | Action                       |
-| --------------- | ---------------------------- |
-| Shift + Escape  | Toggle Dark Mode             |
-| Shift + F1      | Brightness 10% + Dark Mode   |
-| Shift + F2      | Brightness 100% + Light Mode |
-| Shift + F3-F5   | Brightness 0% / 50% / 100%   |
-| Shift + F10-F12 | Volume 0% / 10% / 100%       |
+| Keys            | Action                                |
+| --------------- | ------------------------------------- |
+| Shift + Escape  | Toggle Dark Mode                      |
+| Shift + F1      | Brightness 10% + Dark Mode            |
+| Shift + F2      | Focus profile + Keyboard Backlight 0% |
+| Shift + F3-F5   | Brightness 0% / 50% / 100%            |
+| Shift + F10-F12 | Volume 0% / 10% / 100%                |
 
 **Window Tiling** (macOS + Windows + Linux/X11):
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -213,6 +213,26 @@ impl Default for WallpaperPreferences {
     }
 }
 
+/// Keyboard backlight (beta) preferences. Controls the slider and command
+/// behavior for the built-in laptop keyboard backlight. When `enabled` is
+/// false, the UI hides the slider AND the `command/changeKeyboardBacklight/*`
+/// command becomes a no-op (a master kill-switch). The slider also auto-hides
+/// when the platform layer reports the device as unsupported (e.g. desktop
+/// Macs, non-Lenovo/Dell Windows PCs).
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct KeyboardBacklightPreferences {
+    /// Master toggle. When false the slider is hidden and shortcut commands
+    /// are ignored. Default: true (beta — opt-out, not opt-in).
+    pub enabled: bool,
+}
+
+impl Default for KeyboardBacklightPreferences {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 /// A named window layout preset containing one or more layout rules.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase", default)]
@@ -250,6 +270,8 @@ pub struct Preferences {
     pub layout_presets: Vec<LayoutPreset>,
     /// Wallpaper preferences: fit mode and current wallpaper path.
     pub wallpaper: WallpaperPreferences,
+    /// Keyboard backlight (beta) preferences. See `KeyboardBacklightPreferences`.
+    pub keyboard_backlight: KeyboardBacklightPreferences,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -303,9 +325,15 @@ impl Default for Preferences {
                     key: "Shift+F1".into(),
                     command: CommandValue::Single("command/changeProfile/1".into()),
                 },
+                // Shift+F2: combo binding. Activates profile 2 (Focus) AND
+                // dims the keyboard backlight to 0. Mirrors the "dim everything"
+                // intent — same shortcut, two coordinated dims.
                 KeyBinding {
                     key: "Shift+F2".into(),
-                    command: CommandValue::Single("command/changeProfile/2".into()),
+                    command: CommandValue::Multiple(vec![
+                        "command/changeProfile/2".into(),
+                        "command/changeKeyboardBacklight/0".into(),
+                    ]),
                 },
                 KeyBinding {
                     key: "Shift+F3".into(),
@@ -454,6 +482,7 @@ impl Default for Preferences {
             tiling: TilingPreferences::default(),
             layout_presets: Vec::new(),
             wallpaper: WallpaperPreferences::default(),
+            keyboard_backlight: KeyboardBacklightPreferences::default(),
         }
     }
 }
@@ -943,6 +972,62 @@ mod tests {
         assert_eq!(keys[1], "Shift+F1");
         assert_eq!(keys[7], "Shift+F11");
         assert_eq!(keys[8], "Shift+F12");
+    }
+
+    /// Shift+F2 is a combo binding: it must run BOTH changeProfile/2 and
+    /// changeKeyboardBacklight/0. Single-command form is a regression.
+    #[test]
+    fn test_shift_f2_includes_keyboard_backlight_zero() {
+        let prefs = Preferences::default();
+        let f2 = prefs
+            .key_bindings
+            .iter()
+            .find(|kb| kb.key == "Shift+F2")
+            .expect("Shift+F2 default binding must exist");
+        match &f2.command {
+            CommandValue::Multiple(cmds) => {
+                assert!(
+                    cmds.iter().any(|c| c == "command/changeProfile/2"),
+                    "Shift+F2 must still trigger profile 2 (Focus): {:?}",
+                    cmds
+                );
+                assert!(
+                    cmds.iter().any(|c| c == "command/changeKeyboardBacklight/0"),
+                    "Shift+F2 must also dim the keyboard backlight to 0: {:?}",
+                    cmds
+                );
+            }
+            CommandValue::Single(s) => panic!(
+                "Shift+F2 must be CommandValue::Multiple now, got Single({:?})",
+                s
+            ),
+        }
+    }
+
+    /// Old preferences.json files written before keyboardBacklight existed
+    /// must deserialize with enabled = true (opt-out, not opt-in).
+    #[test]
+    fn test_keyboard_backlight_missing_field_defaults_enabled() {
+        let json = r#"{ "keyBindings": [] }"#;
+        let prefs: Preferences = serde_json::from_str(json).unwrap();
+        assert!(prefs.keyboard_backlight.enabled);
+    }
+
+    /// KeyboardBacklightPreferences roundtrips through serde with camelCase.
+    #[test]
+    fn test_keyboard_backlight_preferences_serde_roundtrip() {
+        let kb = KeyboardBacklightPreferences { enabled: false };
+        let json = serde_json::to_string(&kb).unwrap();
+        assert!(json.contains("\"enabled\":false"));
+        let parsed: KeyboardBacklightPreferences = serde_json::from_str(&json).unwrap();
+        assert!(!parsed.enabled);
+    }
+
+    /// Default KeyboardBacklightPreferences is enabled = true (beta opt-out).
+    #[test]
+    fn test_keyboard_backlight_preferences_default_enabled() {
+        let kb = KeyboardBacklightPreferences::default();
+        assert!(kb.enabled);
     }
 
     #[test]

--- a/src-tauri/src/core/keyboard_backlight.rs
+++ b/src-tauri/src/core/keyboard_backlight.rs
@@ -1,0 +1,567 @@
+// =========================================================================
+// Keyboard backlight — controls the built-in laptop keyboard backlight LED.
+// Beta feature. Not vendored from display-dj-cli — display-dj-local.
+//
+// macOS: IOHIDEventSystem private (but stable since 10.7) — set the
+//        "KeyboardBacklightBrightness" property on the IOHIDServiceClient
+//        whose primary HID usage is page 0x0B (LEDs) usage 0x4B (keyboard
+//        backlight). Same path used by Lunar / kbdlight / BetterTouchTool.
+//        Symbols loaded via dlopen so a future SDK rename degrades to
+//        is_supported() = false instead of crashing at link time.
+//
+// Windows: vendor WMI only — Lenovo (ThinkPad/IdeaPad) and Dell
+//          (Latitude/XPS) via PowerShell. First vendor that responds wins.
+//          All spawns route through hidden_command (Windows console-flash rule).
+//
+// Linux:  out of scope for v7.0.26. is_supported() returns false; get/set
+//         are no-ops. Future: /sys/class/leds/*::kbd_backlight/ or UPower.
+//
+// External keyboards (Razer / Corsair / Logitech, USB-HID generic, Bluetooth):
+//   not supported in any backend. Out of scope.
+// =========================================================================
+
+#[cfg(target_os = "windows")]
+use super::win_cmd::hidden_command;
+
+/// Snap a 0..100 value to the nearest 25% step (0/25/50/75/100). Caller-side
+/// guarantee so both the slider and the keybinding shortcut produce the same
+/// reachable backlight levels — never a 73 or a 42.
+pub fn snap_to_25(value: u32) -> u32 {
+    let clamped = value.min(100);
+    let snapped = ((clamped as f32 / 25.0).round() as u32) * 25;
+    snapped.min(100)
+}
+
+// ----------------------------------------------------------------------- macOS
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::ffi::{c_void, CString};
+    use std::os::raw::c_char;
+    use std::sync::OnceLock;
+
+    // Opaque pointer types — IOKit / CoreFoundation handles. Rust doesn't need
+    // to know the layout, only that they're pointer-sized references.
+    type CFTypeRef = *const c_void;
+    type CFAllocatorRef = *const c_void;
+    type CFStringRef = *const c_void;
+    type CFNumberRef = *const c_void;
+    type CFArrayRef = *const c_void;
+    // CFIndex is `long` on macOS — declared as i64 to match the existing
+    // tiling/macos.rs extern declarations (one source of truth across crates).
+    type CFIndex = i64;
+
+    type IOHIDEventSystemClientRef = *const c_void;
+    type IOHIDServiceClientRef = *const c_void;
+
+    // CFNumber type codes — kCFNumberSInt32Type. Declared as i64 to match
+    // the CFNumberType (CFIndex) signature used elsewhere in the crate.
+    const K_CF_NUMBER_SINT_32_TYPE: i64 = 3;
+
+    // HID page/usage we want to match. Page 0x0B is "LEDs"; usage 0x4B is
+    // "Keyboard Backlight." This is the same matching tuple Lunar uses.
+    const HID_PAGE_LEDS: i32 = 0x0B;
+    const HID_USAGE_KEYBOARD_BACKLIGHT: i32 = 0x4B;
+
+    // Property keys (UTF-8 — converted to CFString at call time).
+    const KEY_PRIMARY_USAGE_PAGE: &str = "PrimaryUsagePage";
+    const KEY_PRIMARY_USAGE: &str = "PrimaryUsage";
+    const KEY_BRIGHTNESS: &str = "KeyboardBacklightBrightness";
+
+    // Brightness is a CFNumber in [0, 65535]. The HID spec says LED usages are
+    // 0..MAX_INT but Apple's driver clips at 0xFFFF.
+    const MAX_HW: f32 = 65535.0;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(
+            alloc: CFAllocatorRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CFStringRef;
+        fn CFNumberCreate(
+            alloc: CFAllocatorRef,
+            type_code: i64,
+            value_ptr: *const c_void,
+        ) -> CFNumberRef;
+        fn CFNumberGetValue(
+            number: CFNumberRef,
+            type_code: i64,
+            out: *mut c_void,
+        ) -> bool;
+        fn CFArrayGetCount(arr: CFArrayRef) -> CFIndex;
+        fn CFArrayGetValueAtIndex(arr: CFArrayRef, idx: CFIndex) -> *const c_void;
+        fn CFRelease(cf: CFTypeRef);
+    }
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
+
+    // dlopen / dlsym — IOHIDEventSystem* symbols live in the private
+    // IOKit framework. Loading at runtime lets us degrade to "unsupported"
+    // instead of failing to link if Apple ever drops the symbols.
+    type DlsymHandle = *mut c_void;
+    const RTLD_NOW: i32 = 2;
+    const RTLD_GLOBAL: i32 = 8;
+
+    extern "C" {
+        fn dlopen(filename: *const c_char, flag: i32) -> DlsymHandle;
+        fn dlsym(handle: DlsymHandle, symbol: *const c_char) -> *mut c_void;
+    }
+
+    type CreateClientFn = unsafe extern "C" fn(CFAllocatorRef) -> IOHIDEventSystemClientRef;
+    type CopyServicesFn = unsafe extern "C" fn(IOHIDEventSystemClientRef) -> CFArrayRef;
+    type CopyPropertyFn =
+        unsafe extern "C" fn(IOHIDServiceClientRef, CFStringRef) -> CFTypeRef;
+    type SetPropertyFn =
+        unsafe extern "C" fn(IOHIDServiceClientRef, CFStringRef, CFTypeRef) -> bool;
+    type ConformsToFn =
+        unsafe extern "C" fn(IOHIDServiceClientRef, i32, i32) -> bool;
+
+    /// Resolved function pointers from the private IOKit framework.
+    struct IoHidFns {
+        create_client: CreateClientFn,
+        copy_services: CopyServicesFn,
+        copy_property: CopyPropertyFn,
+        set_property: SetPropertyFn,
+        conforms_to: ConformsToFn,
+    }
+
+    /// Cache the framework load + symbol resolution. None means the framework
+    /// or symbols are missing — caller should treat as "unsupported."
+    fn fns() -> Option<&'static IoHidFns> {
+        static CACHE: OnceLock<Option<IoHidFns>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| unsafe {
+                let path = CString::new(
+                    "/System/Library/Frameworks/IOKit.framework/IOKit",
+                )
+                .ok()?;
+                let handle = dlopen(path.as_ptr(), RTLD_NOW | RTLD_GLOBAL);
+                if handle.is_null() {
+                    return None;
+                }
+
+                let load = |name: &str| -> *mut c_void {
+                    CString::new(name)
+                        .ok()
+                        .and_then(|c| {
+                            let p = dlsym(handle, c.as_ptr());
+                            if p.is_null() { None } else { Some(p) }
+                        })
+                        .unwrap_or(std::ptr::null_mut())
+                };
+
+                let create = load("IOHIDEventSystemClientCreate");
+                let services = load("IOHIDEventSystemClientCopyServices");
+                let copy_prop = load("IOHIDServiceClientCopyProperty");
+                let set_prop = load("IOHIDServiceClientSetProperty");
+                let conforms = load("IOHIDServiceClientConformsTo");
+
+                if create.is_null()
+                    || services.is_null()
+                    || copy_prop.is_null()
+                    || set_prop.is_null()
+                    || conforms.is_null()
+                {
+                    return None;
+                }
+
+                Some(IoHidFns {
+                    create_client: std::mem::transmute(create),
+                    copy_services: std::mem::transmute(services),
+                    copy_property: std::mem::transmute(copy_prop),
+                    set_property: std::mem::transmute(set_prop),
+                    conforms_to: std::mem::transmute(conforms),
+                })
+            })
+            .as_ref()
+    }
+
+    /// Create a CFString from a Rust &str. Caller must CFRelease.
+    unsafe fn cf_str(s: &str) -> CFStringRef {
+        let c = match CString::new(s) {
+            Ok(c) => c,
+            Err(_) => return std::ptr::null(),
+        };
+        CFStringCreateWithCString(std::ptr::null(), c.as_ptr(), K_CF_STRING_ENCODING_UTF8)
+    }
+
+    /// Walk all IOHIDServiceClients on the system and return the first one
+    /// whose primary usage page/usage matches keyboard backlight.
+    unsafe fn find_backlight_service(fns: &IoHidFns) -> Option<IOHIDServiceClientRef> {
+        let client = (fns.create_client)(std::ptr::null());
+        if client.is_null() {
+            return None;
+        }
+
+        let services = (fns.copy_services)(client);
+        if services.is_null() {
+            CFRelease(client);
+            return None;
+        }
+
+        let count = CFArrayGetCount(services);
+        let key_page = cf_str(KEY_PRIMARY_USAGE_PAGE);
+        let key_usage = cf_str(KEY_PRIMARY_USAGE);
+
+        let mut found: Option<IOHIDServiceClientRef> = None;
+        for i in 0..count {
+            let svc = CFArrayGetValueAtIndex(services, i) as IOHIDServiceClientRef;
+            if svc.is_null() {
+                continue;
+            }
+
+            // Fast path: ask the service directly if it conforms to LEDs/backlight.
+            if (fns.conforms_to)(svc, HID_PAGE_LEDS, HID_USAGE_KEYBOARD_BACKLIGHT) {
+                found = Some(svc);
+                break;
+            }
+
+            // Fallback: inspect PrimaryUsagePage + PrimaryUsage properties.
+            let page_ref = (fns.copy_property)(svc, key_page);
+            let usage_ref = (fns.copy_property)(svc, key_usage);
+            if !page_ref.is_null() && !usage_ref.is_null() {
+                let mut page: i32 = 0;
+                let mut usage: i32 = 0;
+                CFNumberGetValue(
+                    page_ref,
+                    K_CF_NUMBER_SINT_32_TYPE,
+                    &mut page as *mut _ as *mut c_void,
+                );
+                CFNumberGetValue(
+                    usage_ref,
+                    K_CF_NUMBER_SINT_32_TYPE,
+                    &mut usage as *mut _ as *mut c_void,
+                );
+                if page == HID_PAGE_LEDS && usage == HID_USAGE_KEYBOARD_BACKLIGHT {
+                    found = Some(svc);
+                    // fall through to release page/usage refs then break
+                }
+            }
+            if !page_ref.is_null() {
+                CFRelease(page_ref);
+            }
+            if !usage_ref.is_null() {
+                CFRelease(usage_ref);
+            }
+            if found.is_some() {
+                break;
+            }
+        }
+
+        if !key_page.is_null() {
+            CFRelease(key_page);
+        }
+        if !key_usage.is_null() {
+            CFRelease(key_usage);
+        }
+        // NOTE: we intentionally do NOT CFRelease the services array or the
+        // client here in the success path — the service pointer we hand back
+        // is owned by them. Caller is short-lived (get_/set_ returns
+        // immediately) so leaking the wrapper handles for a few microseconds
+        // is acceptable. If this becomes a long-running probe loop, switch to
+        // copying the service ref via CFRetain + releasing the container.
+        if found.is_none() {
+            CFRelease(services);
+            CFRelease(client);
+        }
+
+        found
+    }
+
+    /// Read the current keyboard backlight as 0..100, or None if unsupported.
+    pub fn get() -> Option<u32> {
+        let fns = fns()?;
+        unsafe {
+            let svc = find_backlight_service(fns)?;
+            let key = cf_str(KEY_BRIGHTNESS);
+            if key.is_null() {
+                return None;
+            }
+            let value_ref = (fns.copy_property)(svc, key);
+            CFRelease(key);
+            if value_ref.is_null() {
+                return None;
+            }
+            let mut raw: i32 = 0;
+            let ok = CFNumberGetValue(
+                value_ref,
+                K_CF_NUMBER_SINT_32_TYPE,
+                &mut raw as *mut _ as *mut c_void,
+            );
+            CFRelease(value_ref);
+            if !ok || raw < 0 {
+                return None;
+            }
+            let pct = ((raw as f32 / MAX_HW) * 100.0).round();
+            Some(pct.clamp(0.0, 100.0) as u32)
+        }
+    }
+
+    /// Set the keyboard backlight to `level_pct` (0..100). Returns true on
+    /// platform-layer success. Caller is expected to have already snapped
+    /// the value to 0/25/50/75/100.
+    pub fn set(level_pct: u32) -> bool {
+        let fns = match fns() {
+            Some(f) => f,
+            None => return false,
+        };
+        let pct = level_pct.min(100);
+        let raw_hw = ((pct as f32 / 100.0) * MAX_HW).round() as i32;
+        unsafe {
+            let svc = match find_backlight_service(fns) {
+                Some(s) => s,
+                None => return false,
+            };
+            let key = cf_str(KEY_BRIGHTNESS);
+            if key.is_null() {
+                return false;
+            }
+            let value =
+                CFNumberCreate(std::ptr::null(), K_CF_NUMBER_SINT_32_TYPE, &raw_hw as *const _ as *const c_void);
+            if value.is_null() {
+                CFRelease(key);
+                return false;
+            }
+            let ok = (fns.set_property)(svc, key, value);
+            CFRelease(value);
+            CFRelease(key);
+            ok
+        }
+    }
+
+    pub fn is_supported() -> bool {
+        // Cheapest possible probe: do we have the symbols AND can we find a
+        // service? Result not cached at this layer — `SidecarCache` caches
+        // the high-level Tauri command result.
+        if fns().is_none() {
+            return false;
+        }
+        unsafe {
+            let fns_ref = match fns() {
+                Some(f) => f,
+                None => return false,
+            };
+            find_backlight_service(fns_ref).is_some()
+        }
+    }
+}
+
+// ----------------------------------------------------------------------- Windows
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::hidden_command;
+
+    /// Probe Lenovo's WMI keyboard-backlight namespace. Returns Some(level 0..100)
+    /// if a Lenovo-flavored backlight method responded, None otherwise. The
+    /// PowerShell snippet is intentionally tolerant — many ThinkPad SKUs expose
+    /// the level under slightly different names (`Lenovo_GSensor`, `Lenovo_BIOSElement`,
+    /// dedicated `Lenovo_BIOSSetting` row), so we probe a couple of paths and
+    /// take the first non-empty integer in [0, 100].
+    fn lenovo_get() -> Option<u32> {
+        let out = hidden_command("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                r#"try {
+                    $g = Get-CimInstance -Namespace root\wmi -ClassName Lenovo_KeyboardBacklightLevel -ErrorAction SilentlyContinue
+                    if ($g -and $g.CurrentLevel -ne $null) { Write-Output $g.CurrentLevel; exit 0 }
+                } catch {}
+                exit 1"#,
+            ])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        let raw: u32 = s.parse().ok()?;
+        // Lenovo levels are 0..2 on most ThinkPads. Translate to %.
+        match raw {
+            0 => Some(0),
+            1 => Some(50),
+            2 => Some(100),
+            _ => Some(raw.min(100)),
+        }
+    }
+
+    fn lenovo_set(level_pct: u32) -> bool {
+        // Map 0/25/50/75/100 → Lenovo's 0/1/2 (off/dim/bright).
+        let lenovo_level = match level_pct {
+            0 => 0u32,
+            1..=49 => 1u32,
+            _ => 2u32,
+        };
+        let cmd = format!(
+            r#"try {{
+                $m = Get-CimInstance -Namespace root\wmi -ClassName Lenovo_SetKeyboardBacklightLevel -ErrorAction Stop
+                Invoke-CimMethod -InputObject $m -MethodName SetKeyboardBacklightStatus -Arguments @{{ Level = {} }} | Out-Null
+                exit 0
+            }} catch {{
+                exit 1
+            }}"#,
+            lenovo_level
+        );
+        hidden_command("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &cmd])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn dell_get() -> Option<u32> {
+        let out = hidden_command("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                r#"try {
+                    $g = Get-CimInstance -Namespace root\wmi -ClassName DellKeyboardBacklight -ErrorAction SilentlyContinue
+                    if ($g -and $g.Level -ne $null) { Write-Output $g.Level; exit 0 }
+                } catch {}
+                exit 1"#,
+            ])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        let raw: u32 = s.parse().ok()?;
+        // Dell levels are 0..2 on most Latitudes (off/dim/bright).
+        match raw {
+            0 => Some(0),
+            1 => Some(50),
+            2 => Some(100),
+            _ => Some(raw.min(100)),
+        }
+    }
+
+    fn dell_set(level_pct: u32) -> bool {
+        let dell_level = match level_pct {
+            0 => 0u32,
+            1..=49 => 1u32,
+            _ => 2u32,
+        };
+        let cmd = format!(
+            r#"try {{
+                $m = Get-CimInstance -Namespace root\wmi -ClassName DellKeyboardBacklight -ErrorAction Stop
+                Invoke-CimMethod -InputObject $m -MethodName SetKeyboardBacklightLevel -Arguments @{{ Level = {} }} | Out-Null
+                exit 0
+            }} catch {{
+                exit 1
+            }}"#,
+            dell_level
+        );
+        hidden_command("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &cmd])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    pub fn get() -> Option<u32> {
+        lenovo_get().or_else(dell_get)
+    }
+
+    pub fn set(level_pct: u32) -> bool {
+        // Try the same vendor order we probed for `get`. First success wins.
+        if lenovo_set(level_pct) {
+            return true;
+        }
+        dell_set(level_pct)
+    }
+
+    pub fn is_supported() -> bool {
+        get().is_some()
+    }
+}
+
+// ----------------------------------------------------------------------- Linux / fallback
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod imp {
+    pub fn get() -> Option<u32> {
+        None
+    }
+    pub fn set(_level_pct: u32) -> bool {
+        false
+    }
+    pub fn is_supported() -> bool {
+        false
+    }
+}
+
+/// Returns the current keyboard backlight as a 0..100 percentage, or `None` if
+/// no supported backend reports a value (treat as "unsupported on this device").
+pub fn get_keyboard_backlight() -> Option<u32> {
+    imp::get()
+}
+
+/// Sets the keyboard backlight to `level_pct` (0..100, snapped to 25 by caller).
+/// Returns true if the platform layer accepted the write.
+pub fn set_keyboard_backlight(level_pct: u32) -> bool {
+    imp::set(snap_to_25(level_pct))
+}
+
+/// Returns true when at least one backend can read the current backlight level
+/// on this device. Used at startup to decide whether to render the slider.
+pub fn is_supported() -> bool {
+    imp::is_supported()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// snap_to_25 must round to the nearest 25-step and clamp at 100.
+    #[test]
+    fn snap_to_25_rounds_to_nearest_step() {
+        assert_eq!(snap_to_25(0), 0);
+        assert_eq!(snap_to_25(1), 0);
+        assert_eq!(snap_to_25(12), 0); // < midpoint → down
+        assert_eq!(snap_to_25(13), 25); // ≥ midpoint → up
+        assert_eq!(snap_to_25(25), 25);
+        assert_eq!(snap_to_25(37), 25);
+        assert_eq!(snap_to_25(38), 50);
+        assert_eq!(snap_to_25(50), 50);
+        assert_eq!(snap_to_25(75), 75);
+        assert_eq!(snap_to_25(99), 100);
+        assert_eq!(snap_to_25(100), 100);
+    }
+
+    /// snap_to_25 clamps out-of-range input to 100 instead of overflowing.
+    #[test]
+    fn snap_to_25_clamps_above_100() {
+        assert_eq!(snap_to_25(150), 100);
+        assert_eq!(snap_to_25(u32::MAX), 100);
+    }
+
+    /// get_keyboard_backlight must not panic on any platform.
+    /// On CI Linux / unsupported devices it should return None.
+    #[test]
+    fn get_keyboard_backlight_smoke() {
+        let _ = get_keyboard_backlight();
+    }
+
+    /// is_supported must not panic and returns a deterministic bool.
+    #[test]
+    fn is_supported_smoke() {
+        let _ = is_supported();
+    }
+
+    /// set_keyboard_backlight is callable with any 0..100 value without
+    /// panicking. We don't assert success — the test runner may be on a
+    /// keyboard-backlight-less machine. Restore to previous state after.
+    #[test]
+    fn set_keyboard_backlight_smoke() {
+        let original = get_keyboard_backlight();
+        let _ = set_keyboard_backlight(50);
+        // Best-effort restore. No-op when unsupported.
+        if let Some(prev) = original {
+            let _ = set_keyboard_backlight(prev);
+        }
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -16,6 +16,7 @@ pub mod win_cmd;
 
 pub mod theme;
 pub mod volume;
+pub mod keyboard_backlight;
 pub mod wallpaper;
 pub mod display;
 

--- a/src-tauri/src/keyboard_backlight.rs
+++ b/src-tauri/src/keyboard_backlight.rs
@@ -1,0 +1,150 @@
+use tauri::{Emitter, Manager};
+
+/// Returns the current keyboard backlight level (0..100) via the in-process
+/// platform layer, or `None` if no supported backend reports a value on this
+/// device. Uses the 5-minute SidecarCache to avoid re-probing on every poll
+/// (parallel to the volume / dark-mode commands).
+#[tauri::command]
+pub async fn get_keyboard_backlight(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Option<u32>, String> {
+    let t0 = std::time::Instant::now();
+    crate::config::write_debug_log(&state, "benchmark: get_keyboard_backlight — START");
+
+    if let Some(cached) = state.sidecar_cache.get_keyboard_backlight() {
+        crate::config::write_debug_log(
+            &state,
+            &format!(
+                "benchmark: get_keyboard_backlight — {:.1}ms (cache hit)",
+                t0.elapsed().as_secs_f64() * 1000.0,
+            ),
+        );
+        return Ok(Some(cached));
+    }
+
+    let level = tauri::async_runtime::spawn_blocking(
+        crate::core::keyboard_backlight::get_keyboard_backlight,
+    )
+    .await
+    .map_err(|e| format!("get_keyboard_backlight task join failed: {}", e))?;
+
+    if let Some(v) = level {
+        state.sidecar_cache.set_keyboard_backlight(v);
+    }
+
+    crate::config::write_debug_log(
+        &state,
+        &format!(
+            "benchmark: get_keyboard_backlight — {:.1}ms (probe, level={:?})",
+            t0.elapsed().as_secs_f64() * 1000.0,
+            level,
+        ),
+    );
+    Ok(level)
+}
+
+/// Sets the keyboard backlight level. Clamped to 0..100 and snapped to the
+/// nearest 25% step (so the only reachable levels are 0/25/50/75/100, matching
+/// the slider step on the frontend). Invalidates the cache and emits
+/// `keyboard-backlight-changed` so the UI refetches.
+#[tauri::command]
+pub async fn set_keyboard_backlight(value: u32, app: tauri::AppHandle) -> Result<(), String> {
+    let t0 = std::time::Instant::now();
+    let snapped = crate::core::keyboard_backlight::snap_to_25(value);
+    log::info!(
+        "set_keyboard_backlight: value={} snapped={}",
+        value,
+        snapped
+    );
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        crate::config::write_debug_log(
+            &state,
+            &format!(
+                "set_keyboard_backlight: value={} snapped={} — START",
+                value, snapped
+            ),
+        );
+    }
+
+    let ok = tauri::async_runtime::spawn_blocking(move || {
+        crate::core::keyboard_backlight::set_keyboard_backlight(snapped)
+    })
+    .await
+    .map_err(|e| format!("set_keyboard_backlight task join failed: {}", e))?;
+
+    if !ok {
+        log::warn!("set_keyboard_backlight: platform layer reported failure");
+    }
+    let elapsed = t0.elapsed().as_secs_f64() * 1000.0;
+    log::info!(
+        "set_keyboard_backlight: done platform_ok={} elapsed={:.1}ms",
+        ok,
+        elapsed,
+    );
+
+    if let Some(state) = app.try_state::<crate::AppState>() {
+        state.sidecar_cache.invalidate_keyboard_backlight();
+        crate::config::write_debug_log(
+            &state,
+            &format!(
+                "set_keyboard_backlight: value={} platform_ok={} — {:.1}ms",
+                snapped, ok, elapsed,
+            ),
+        );
+    }
+
+    let _ = app.emit("keyboard-backlight-changed", ());
+    Ok(())
+}
+
+/// Returns true if any backend on this device can read the keyboard backlight.
+/// Called once on app startup so the frontend can decide whether to render the
+/// slider. Result NOT cached — the probe is cheap (one IOKit / WMI call) and
+/// hardware can be plugged in/out at runtime.
+#[tauri::command]
+pub async fn get_keyboard_backlight_supported() -> Result<bool, String> {
+    tauri::async_runtime::spawn_blocking(crate::core::keyboard_backlight::is_supported)
+        .await
+        .map_err(|e| format!("get_keyboard_backlight_supported task join failed: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AppState;
+    use tauri::Manager;
+
+    /// Build a fully-managed Tauri test app for command invocation.
+    fn make_test_app() -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_app();
+        app.manage(AppState::default());
+        app
+    }
+
+    /// get_keyboard_backlight returns Ok regardless of platform support.
+    #[test]
+    fn test_get_keyboard_backlight_returns_value() {
+        let app = make_test_app();
+        let state = app.state::<AppState>();
+        let result = tauri::async_runtime::block_on(get_keyboard_backlight(state));
+        assert!(result.is_ok());
+    }
+
+    /// get_keyboard_backlight hits the cache on the second call.
+    #[test]
+    fn test_get_keyboard_backlight_uses_cache() {
+        let app = make_test_app();
+        app.state::<AppState>().sidecar_cache.set_keyboard_backlight(75);
+        let state = app.state::<AppState>();
+        let result = tauri::async_runtime::block_on(get_keyboard_backlight(state)).unwrap();
+        assert_eq!(result, Some(75));
+    }
+
+    /// get_keyboard_backlight_supported returns Ok(bool).
+    #[test]
+    fn test_get_keyboard_backlight_supported_returns_bool() {
+        let result =
+            tauri::async_runtime::block_on(get_keyboard_backlight_supported());
+        assert!(result.is_ok());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ pub mod core;
 mod dark_mode;
 mod display;
 mod keep_awake;
+mod keyboard_backlight;
 mod overlay;
 pub mod sidecar_cache;
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
@@ -638,6 +639,9 @@ pub fn run() {
             dark_mode::set_dark_mode,
             volume::get_volume,
             volume::set_volume,
+            keyboard_backlight::get_keyboard_backlight,
+            keyboard_backlight::set_keyboard_backlight,
+            keyboard_backlight::get_keyboard_backlight_supported,
             config::get_preferences,
             config::save_preferences,
             config::open_preferences_file,

--- a/src-tauri/src/sidecar_cache.rs
+++ b/src-tauri/src/sidecar_cache.rs
@@ -38,6 +38,9 @@ pub struct SidecarCache {
     dark_mode: Mutex<Option<CacheEntry<bool>>>,
     /// Cached volume level (from `core::volume::get_volume()`).
     volume: Mutex<Option<CacheEntry<u32>>>,
+    /// Cached keyboard-backlight level 0..100
+    /// (from `core::keyboard_backlight::get_keyboard_backlight()`).
+    keyboard_backlight: Mutex<Option<CacheEntry<u32>>>,
     /// Cached macOS Accessibility permission status (AXIsProcessTrusted).
     accessibility: Mutex<Option<CacheEntry<bool>>>,
 }
@@ -49,6 +52,7 @@ impl SidecarCache {
             monitors: Mutex::new(None),
             dark_mode: Mutex::new(None),
             volume: Mutex::new(None),
+            keyboard_backlight: Mutex::new(None),
             accessibility: Mutex::new(None),
         }
     }
@@ -103,6 +107,29 @@ impl SidecarCache {
         }
     }
 
+    /// Get cached keyboard backlight level if fresh, otherwise None.
+    pub fn get_keyboard_backlight(&self) -> Option<u32> {
+        let lock = self.keyboard_backlight.lock().ok()?;
+        lock.as_ref().filter(|e| e.is_fresh()).map(|e| e.value)
+    }
+
+    /// Store keyboard backlight level in cache.
+    pub fn set_keyboard_backlight(&self, level: u32) {
+        if let Ok(mut lock) = self.keyboard_backlight.lock() {
+            *lock = Some(CacheEntry {
+                value: level,
+                fetched_at: Instant::now(),
+            });
+        }
+    }
+
+    /// Invalidate the keyboard backlight cache (e.g., after set_keyboard_backlight).
+    pub fn invalidate_keyboard_backlight(&self) {
+        if let Ok(mut lock) = self.keyboard_backlight.lock() {
+            *lock = None;
+        }
+    }
+
     /// Get cached accessibility status if fresh, otherwise None.
     pub fn get_accessibility(&self) -> Option<bool> {
         let lock = self.accessibility.lock().ok()?;
@@ -152,6 +179,7 @@ impl SidecarCache {
         self.invalidate_monitors();
         self.invalidate_dark_mode();
         self.invalidate_volume();
+        self.invalidate_keyboard_backlight();
         self.invalidate_accessibility();
     }
 }
@@ -187,6 +215,7 @@ mod tests {
         assert!(cache.get_monitors().is_none());
         assert!(cache.get_dark_mode().is_none());
         assert!(cache.get_volume().is_none());
+        assert!(cache.get_keyboard_backlight().is_none());
         assert!(cache.get_accessibility().is_none());
     }
 
@@ -196,6 +225,7 @@ mod tests {
         assert!(cache.get_monitors().is_none());
         assert!(cache.get_dark_mode().is_none());
         assert!(cache.get_volume().is_none());
+        assert!(cache.get_keyboard_backlight().is_none());
         assert!(cache.get_accessibility().is_none());
     }
 
@@ -225,6 +255,24 @@ mod tests {
         assert_eq!(cache.get_volume(), Some(75));
         cache.set_volume(0);
         assert_eq!(cache.get_volume(), Some(0));
+    }
+
+    #[test]
+    fn test_set_get_keyboard_backlight() {
+        let cache = SidecarCache::new();
+        cache.set_keyboard_backlight(50);
+        assert_eq!(cache.get_keyboard_backlight(), Some(50));
+        cache.set_keyboard_backlight(0);
+        assert_eq!(cache.get_keyboard_backlight(), Some(0));
+    }
+
+    #[test]
+    fn test_invalidate_keyboard_backlight() {
+        let cache = SidecarCache::new();
+        cache.set_keyboard_backlight(75);
+        assert_eq!(cache.get_keyboard_backlight(), Some(75));
+        cache.invalidate_keyboard_backlight();
+        assert!(cache.get_keyboard_backlight().is_none());
     }
 
     #[test]
@@ -266,6 +314,7 @@ mod tests {
         cache.set_monitors(vec![make_monitor("1")]);
         cache.set_dark_mode(true);
         cache.set_volume(50);
+        cache.set_keyboard_backlight(25);
         cache.set_accessibility(true);
 
         cache.invalidate_all();
@@ -273,6 +322,7 @@ mod tests {
         assert!(cache.get_monitors().is_none());
         assert!(cache.get_dark_mode().is_none());
         assert!(cache.get_volume().is_none());
+        assert!(cache.get_keyboard_backlight().is_none());
         assert!(cache.get_accessibility().is_none());
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1125,6 +1125,31 @@ pub(crate) fn execute_command(app: &AppHandle, command: &str) {
                 });
             }
         }
+        // Set keyboard backlight: command/changeKeyboardBacklight/{value}
+        //
+        // Value is clamped to 0..100 then snapped to the nearest 25% step so
+        // shortcut bindings and the slider produce the same reachable levels.
+        // Honors the `keyboardBacklight.enabled` preference — when disabled,
+        // the command no-ops (the UI also hides the slider when disabled).
+        ["command", "changeKeyboardBacklight", value] => {
+            if let Ok(val) = value.parse::<u32>() {
+                let enabled = app
+                    .try_state::<crate::AppState>()
+                    .and_then(|s| s.preferences.lock().ok().map(|p| p.keyboard_backlight.enabled))
+                    .unwrap_or(true);
+                if !enabled {
+                    log::info!("changeKeyboardBacklight: feature disabled in preferences — skipping");
+                    return;
+                }
+                let snapped = crate::core::keyboard_backlight::snap_to_25(val);
+                if let Some(state) = app.try_state::<crate::AppState>() {
+                    state.sidecar_cache.invalidate_keyboard_backlight();
+                }
+                run_then_emit(app.clone(), "keyboard-backlight-changed", move || {
+                    let _ = crate::core::keyboard_backlight::set_keyboard_backlight(snapped);
+                });
+            }
+        }
         ["command", "changeProfile", idx_str] => {
             if let Ok(idx) = idx_str.parse::<usize>() {
                 let profiles = app
@@ -1345,6 +1370,10 @@ mod tests {
             "command/changeContrast/2/70",
             "command/changeContrast/150",
             "command/changeVolume/50",
+            "command/changeKeyboardBacklight/0",
+            "command/changeKeyboardBacklight/50",
+            "command/changeKeyboardBacklight/100",
+            "command/changeKeyboardBacklight/abc",
             "command/changeBrightness/abc",
             "command/changeBrightness/1/abc",
             "command/unknown/123",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-docs/refs/heads/main/schemas/config.schema.json",
   "productName": "Display DJ",
-  "version": "7.0.25",
+  "version": "7.0.26",
   "identifier": "com.synle.display-dj",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -365,6 +365,10 @@ body,
 .volume-section {
 }
 
+/* Keyboard backlight (beta) section — same shape as volume slider. */
+.keyboard-backlight-section {
+}
+
 /* Dark mode toggle */
 .dark-mode-toggle {
   display: flex;
@@ -636,6 +640,13 @@ body,
 
 .settings-checkbox-row input[type='checkbox'] {
   accent-color: var(--accent);
+}
+
+.settings-help {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 2px 0 0 24px;
+  line-height: 1.35;
 }
 
 .settings-schedule-header {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Header from './components/Header';
 import AllMonitorsControl from './components/AllMonitorsControl';
 import MonitorControl from './components/MonitorControl';
 import VolumeControl from './components/VolumeControl';
+import KeyboardBacklightControl from './components/KeyboardBacklightControl';
 import DarkModeToggle from './components/DarkModeToggle';
 import ProfileButtons from './components/ProfileButtons';
 import KeepAwakeToggle from './components/KeepAwakeToggle';
@@ -22,6 +23,9 @@ function App() {
   const [monitors, setMonitors] = useState<Monitor[]>([]);
   const [darkMode, setDarkMode] = useState(false);
   const [volume, setVolume] = useState(50);
+  const [keyboardBacklight, setKeyboardBacklight] = useState(0);
+  const [keyboardBacklightEnabled, setKeyboardBacklightEnabled] = useState(true);
+  const [keyboardBacklightSupported, setKeyboardBacklightSupported] = useState(false);
   const [minBrightness, setMinBrightness] = useState(10);
   const [showContrast, setShowContrast] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
@@ -82,6 +86,19 @@ function App() {
     }
   }, []);
 
+  /** Fetches the current keyboard-backlight level from the backend.
+   * Returns null when the device doesn't support it (we then hide the slider). */
+  const fetchKeyboardBacklight = useCallback(async () => {
+    try {
+      const v = await invoke<number | null>('get_keyboard_backlight');
+      if (v !== null && v !== undefined) {
+        setKeyboardBacklight(v);
+      }
+    } catch (e) {
+      console.error('Failed to get keyboard backlight:', e);
+    }
+  }, []);
+
   /** Fetches the current keep-awake state from the backend. */
   const fetchKeepAwake = useCallback(async () => {
     try {
@@ -99,6 +116,9 @@ function App() {
       setMinBrightness(Math.max(prefs.minBrightness, ABSOLUTE_MIN_BRIGHTNESS));
       setShowContrast(prefs.showContrast ?? false);
       setProfiles(prefs.profiles || []);
+      // Beta keyboard-backlight master toggle. The slider hides when this is
+      // false OR when the platform layer reports the device as unsupported.
+      setKeyboardBacklightEnabled(prefs.keyboardBacklight?.enabled ?? true);
     } catch {
       // ignore
     }
@@ -126,6 +146,17 @@ function App() {
     fetchAllState();
     fetchPreferences();
     fetchKeepAwake();
+    // Keyboard backlight (beta) — probe once for hardware support, then
+    // fetch the current level if supported. `null` from the backend means
+    // unsupported on this device, in which case we never show the slider.
+    invoke<boolean>('get_keyboard_backlight_supported')
+      .then((supported) => {
+        setKeyboardBacklightSupported(supported);
+        if (supported) {
+          fetchKeyboardBacklight();
+        }
+      })
+      .catch(() => setKeyboardBacklightSupported(false));
     // Detect macOS once and track the Accessibility-permission state so we
     // can render a blocking gate when it's missing (tiling/Tile-Snap/exposé
     // silently no-op without it — see CLAUDE.md "macOS Tray Icon Pitfall").
@@ -147,12 +178,24 @@ function App() {
       setAboutOpen(true);
       setSettingsOpen(false);
     });
+    const unlisten5 = listen('keyboard-backlight-changed', () => fetchKeyboardBacklight());
 
     // Also refetch when window becomes visible
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
         fetchAllState();
         fetchKeepAwake();
+        // Re-probe keyboard backlight support on every popup open — laptops
+        // can be docked/undocked and external keyboard hot-plug shouldn't
+        // require an app restart to surface the slider correctly.
+        invoke<boolean>('get_keyboard_backlight_supported')
+          .then((supported) => {
+            setKeyboardBacklightSupported(supported);
+            if (supported) {
+              fetchKeyboardBacklight();
+            }
+          })
+          .catch(() => {});
         invoke<boolean>('get_accessibility_trusted')
           .then(setAccessibilityTrusted)
           .catch(() => {});
@@ -171,10 +214,18 @@ function App() {
       unlisten2.then((f) => f());
       unlisten3.then((f) => f());
       unlisten4.then((f) => f());
+      unlisten5.then((f) => f());
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('blur', handleBlur);
     };
-  }, [fetchMonitors, fetchDarkMode, fetchVolume, fetchPreferences, fetchKeepAwake]);
+  }, [
+    fetchMonitors,
+    fetchDarkMode,
+    fetchVolume,
+    fetchPreferences,
+    fetchKeepAwake,
+    fetchKeyboardBacklight,
+  ]);
 
   // Auto-resize window to fit content
   useEffect(() => {
@@ -301,6 +352,18 @@ function App() {
     }
   };
 
+  /** Sets the keyboard backlight level (snapped to 0/25/50/75/100 by the slider
+   * and again by the backend). Optimistic UI update — refetch on failure. */
+  const handleKeyboardBacklight = async (value: number) => {
+    setKeyboardBacklight(value);
+    try {
+      await invoke('set_keyboard_backlight', { value });
+    } catch (e) {
+      console.error('Failed to set keyboard backlight:', e);
+      fetchKeyboardBacklight();
+    }
+  };
+
   /** Toggles the keep-awake state (prevents system from sleeping). */
   const handleKeepAwake = async (enabled: boolean) => {
     try {
@@ -407,6 +470,12 @@ function App() {
             ))}
 
           <VolumeControl value={volume} onChange={handleVolume} />
+          {keyboardBacklightSupported && keyboardBacklightEnabled && (
+            <KeyboardBacklightControl
+              value={keyboardBacklight}
+              onChange={handleKeyboardBacklight}
+            />
+          )}
           <DarkModeToggle isDarkMode={darkMode} onChange={handleDarkMode} />
           <ProfileButtons profiles={profiles} onActivate={handleProfile} />
           <KeepAwakeToggle isActive={keepAwake} onChange={handleKeepAwake} />

--- a/src/components/KeyboardBacklightControl.test.tsx
+++ b/src/components/KeyboardBacklightControl.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import KeyboardBacklightControl from './KeyboardBacklightControl';
+
+describe('KeyboardBacklightControl', () => {
+  it('renders a slider with the given backlight value', () => {
+    render(<KeyboardBacklightControl value={50} onChange={() => {}} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveValue('50');
+  });
+
+  it('sets step=25 on the underlying input so only 0/25/50/75/100 are reachable', () => {
+    render(<KeyboardBacklightControl value={50} onChange={() => {}} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('step', '25');
+  });
+
+  it('renders the keyboard symbol (U+2328) as the icon', () => {
+    render(<KeyboardBacklightControl value={50} onChange={() => {}} />);
+    expect(screen.getByText('\u2328')).toBeInTheDocument();
+  });
+
+  it('clears (calls onChange with 0) when icon is clicked at a non-zero level', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<KeyboardBacklightControl value={50} onChange={onChange} />);
+    await user.click(screen.getByText('\u2328'));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('restores (calls onChange with 100) when icon is clicked at level zero', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<KeyboardBacklightControl value={0} onChange={onChange} />);
+    await user.click(screen.getByText('\u2328'));
+    expect(onChange).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/components/KeyboardBacklightControl.tsx
+++ b/src/components/KeyboardBacklightControl.tsx
@@ -1,0 +1,38 @@
+import Slider from './Slider';
+
+interface KeyboardBacklightControlProps {
+  /** Current backlight level 0..100. Will be snapped to the nearest 25 by the slider. */
+  value: number;
+  /** Called with the new level (0/25/50/75/100). The backend snaps too, defensively. */
+  onChange: (value: number) => void;
+}
+
+/**
+ * Built-in laptop keyboard backlight slider (beta).
+ *
+ * Stepped at 25% so the only reachable values are 0/25/50/75/100 — matches the
+ * same snap the backend applies to `command/changeKeyboardBacklight/{value}`
+ * shortcut commands, so the slider and the hotkey produce identical hardware
+ * state.
+ *
+ * Icon: U+2328 (⌨) keyboard symbol. Click toggles 0 ↔ 100 like the volume icon
+ * mute/unmute toggle. Caller is responsible for hiding the component entirely
+ * when the platform layer reports the device as unsupported or when
+ * `keyboardBacklight.enabled` is false in preferences.
+ */
+export default function KeyboardBacklightControl({
+  value,
+  onChange,
+}: KeyboardBacklightControlProps) {
+  return (
+    <div className='keyboard-backlight-section'>
+      <Slider
+        icon={'\u2328'}
+        value={value}
+        step={25}
+        onChange={onChange}
+        onIconClick={() => onChange(value > 0 ? 0 : 100)}
+      />
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -233,6 +233,26 @@ export default function SettingsPanel({ onClose, onPreferencesSaved }: SettingsP
               </label>
             </div>
 
+            <div className='settings-section'>
+              <label className='settings-checkbox-row'>
+                <input
+                  type='checkbox'
+                  checked={prefs.keyboardBacklight?.enabled ?? true}
+                  onChange={(e) =>
+                    updateField('keyboardBacklight', {
+                      ...prefs.keyboardBacklight,
+                      enabled: e.target.checked,
+                    })
+                  }
+                />
+                <span>Enable Keyboard Backlight Control (beta)</span>
+              </label>
+              <p className='settings-help'>
+                Beta — built-in macOS keyboards and select Lenovo / Dell laptops only. The slider
+                hides automatically when the device is not supported.
+              </p>
+            </div>
+
             <div className='settings-divider' />
 
             <div className='settings-section'>

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -5,6 +5,13 @@ interface SliderProps {
   value: number;
   min?: number;
   max?: number;
+  /**
+   * Step size for the underlying range input. Defaults to 1 (continuous).
+   * Used by the keyboard-backlight slider to snap to 25% increments so the
+   * only reachable values are 0/25/50/75/100 — matches the same snapping
+   * the backend applies to shortcut commands.
+   */
+  step?: number;
   onChange: (value: number) => void;
   showValue?: boolean;
   unit?: string;
@@ -17,6 +24,7 @@ export default function Slider({
   value,
   min = 0,
   max = 100,
+  step = 1,
   onChange,
   showValue = true,
   unit = '%',
@@ -65,6 +73,7 @@ export default function Slider({
           className='slider-input'
           min={min}
           max={max}
+          step={step}
           value={localValue}
           onChange={handleChange}
         />

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,12 @@ export interface WallpaperPreferences {
   slideshowOrder: string;
 }
 
+/** Keyboard backlight (beta) preferences. */
+export interface KeyboardBacklightPreferences {
+  /** Master toggle. When false the slider is hidden and shortcut commands no-op. */
+  enabled: boolean;
+}
+
 export interface Preferences {
   showIndividualDisplays: boolean;
   minBrightness: number;
@@ -118,6 +124,8 @@ export interface Preferences {
   layoutPresets: LayoutPreset[];
   /** Wallpaper preferences: fit mode and current wallpaper path. */
   wallpaper: WallpaperPreferences;
+  /** Keyboard backlight (beta) preferences. */
+  keyboardBacklight: KeyboardBacklightPreferences;
 }
 
 export interface KeyBinding {


### PR DESCRIPTION
## Summary

- New per-laptop keyboard-backlight slider in the popup directly below volume. Stepped at 25% (only 0/25/50/75/100 reachable; the backend re-snaps so the slider and the new \`command/changeKeyboardBacklight/{value}\` shortcut produce identical hardware state).
- macOS via private-but-stable IOKit \`IOHIDEventSystem\` + \`KeyboardBacklightBrightness\` property (built-in keyboards only; symbols loaded via \`dlopen\` so a future Apple SDK rename degrades to \`is_supported() = false\` instead of failing to link).
- Windows via Lenovo (\`Lenovo_KeyboardBacklightLevel\`) + Dell (\`DellKeyboardBacklight\`) WMI. Other vendors → reports unsupported. All spawns route through \`hidden_command\` (Windows console-flash rule).
- Linux: explicitly out of scope for this patch.
- UI auto-hides the slider when **either** the backend reports unsupported **or** \`keyboardBacklight.enabled = false\` (new Settings checkbox, "Enable Keyboard Backlight Control (beta)", default on).
- Default \`Shift+F2\` is now a \`CommandValue::Multiple\` that runs both \`changeProfile/2\` (Focus) and \`changeKeyboardBacklight/0\` — a single "dim everything" shortcut.

Bumps version to **7.0.26**.

## Test plan

- [x] \`cargo test --lib\` — 360 → 374 backend tests pass (14 new: snap, smoke, supported, cache hit/miss, serde back-compat, Shift+F2 combo, SidecarCache slot, build_command_url regression sweep)
- [x] \`npm test\` — 130 → 135 frontend tests pass (5 new for \`KeyboardBacklightControl\`: render, step=25, icon, toggle 0↔100)
- [x] \`npm run build\` — TS + Vite production build green
- [x] CLAUDE.md size check (rule 52) — 39,776 bytes, under 40k limit
- [x] \`npx prettier --write\` on all changed files
- [x] Secret scan on staged + unstaged diff — clean
- [ ] Manual smoke on a Mac with built-in keyboard — slider moves the backlight, Shift+F2 dims to 0
- [ ] Manual smoke on a desktop Mac / non-Lenovo-non-Dell Windows — slider hides automatically